### PR TITLE
Remove superfluous code from serverspec example

### DIFF
--- a/source/docs/getting-started/writing-server-test.md
+++ b/source/docs/getting-started/writing-server-test.md
@@ -22,14 +22,12 @@ Next, create a file called `test/integration/server/serverspec/git_daemon_spec.r
 
 ~~~ruby
 require 'serverspec'
-require 'pathname'
 
 include Serverspec::Helper::Exec
 include Serverspec::Helper::DetectOS
 
 RSpec.configure do |c|
   c.before :all do
-    c.os = backend(Serverspec::Commands::Base).check_os
     c.path = '/sbin:/usr/sbin'
   end
 end


### PR DESCRIPTION
serverspec does not use `RSpec.configuration.os` anymore, see https://github.com/serverspec/serverspec/commit/797b14015d5a881f5fea531e2df44db672fc1e08#commitcomment-4760496

Also, `pathname` is required, but not used anywhere.

/cc @fnichol @mizzy
