### PR TITLE
Fixed git_daemon_spec.rb required for serverspec 2.0 release

### DIFF
--- a/source/docs/getting-started/writing-server-test.md
+++ b/source/docs/getting-started/writing-server-test.md
@@ -23,14 +23,8 @@ Next, create a file called `test/integration/server/serverspec/git_daemon_spec.r
 ~~~ruby
 require 'serverspec'
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
-
-RSpec.configure do |c|
-  c.before :all do
-    c.path = '/sbin:/usr/sbin'
-  end
-end
+# Required by serverspec
+set :backend, :exec
 
 describe "Git Daemon" do
 


### PR DESCRIPTION
Fixed also started guide https://github.com/test-kitchen/guide-started-git-cookbook/pull/2

See http://lists.opscode.com/sympa/arc/chef/2014-10/msg00035.html for more details.
