### PR TITLE
Fix typo

### DIFF
--- a/source/docs/getting-started/dynamic-configuration.md
+++ b/source/docs/getting-started/dynamic-configuration.md
@@ -12,7 +12,7 @@ There are a few basic ways of dynamically configuring Test Kitchen:
 
 * A local configuration will be looked for in `.kitchen.local.yml` which could be used for development purposes.  This is a file that is not typically checked into version control.
 * A global configuration file will also be looked for in `$HOME/.kitchen/config.yml` to set preferred defaults for all your projects.
-* Finally, each YAML file can contain ERB fragments, which you could use for selecting drivers, etc. based on which platform you're currently running, or based on environment variables.
+* Finally, each YAML file can contain ERB fragments, which you could use for selecting drivers, etc. based on which platform you're currently running, or based off environment variables.
 
 For example, you could modify `.kitchen.yml` (or `.kitchen.local.yml`, or `$HOME/.kitchen/config.yml`) to look like:
 

--- a/source/docs/getting-started/dynamic-configuration.md
+++ b/source/docs/getting-started/dynamic-configuration.md
@@ -12,7 +12,7 @@ There are a few basic ways of dynamically configuring Test Kitchen:
 
 * A local configuration will be looked for in `.kitchen.local.yml` which could be used for development purposes.  This is a file that is not typically checked into version control.
 * A global configuration file will also be looked for in `$HOME/.kitchen/config.yml` to set preferred defaults for all your projects.
-* Finally, each YAML file can contain ERB fragments, which you could use for selecting drivers, etc. based on which platform your currently running, or based of environment variables.
+* Finally, each YAML file can contain ERB fragments, which you could use for selecting drivers, etc. based on which platform you're currently running, or based on environment variables.
 
 For example, you could modify `.kitchen.yml` (or `.kitchen.local.yml`, or `$HOME/.kitchen/config.yml`) to look like:
 


### PR DESCRIPTION
This PR fixes a couple of typos on the Dynamic Configuration page of the Getting Started Guide.