### PR TITLE
Fix Next Steps -> FAQ links at bottom of guide pages

### DIFF
--- a/source/docs/getting-started/faq.md
+++ b/source/docs/getting-started/faq.md
@@ -1,8 +1,8 @@
 ---
 title: "Frequently Asked Questions"
-next:
-  text: "Frequently Asked Questions"
-  url: "faq"
+prev:
+  text: "Next Steps"
+  url: "next-steps"
 ---
 
 ### The defaults are way too small or missing something, how do I change the default Vagrant machine?

--- a/source/docs/getting-started/next-steps.md
+++ b/source/docs/getting-started/next-steps.md
@@ -3,6 +3,9 @@ title: Next Steps
 prev:
   text: "Backfilling Platforms"
   url: "backfilling-platforms"
+next:
+  text: "Frequently Asked Questions"
+  url: "faq"
 ---
 
 This concludes the getting started guide for Test Kitchen. Hopefully you are now more comfortable with Test Kitchen's basic usage, fundamental concepts, and a feel for a testing workflow.


### PR DESCRIPTION
Make FAQ the last page in the guide to match the order in the nav bar.

Which means make Next Steps know FAQ is next and make FAQ know Next
Steps was the previous page.

Signed-off-by: Robb Kidd <robb@thekidds.org>