### PR TITLE
Add required quoting for dynamic config example

### DIFF
--- a/source/docs/getting-started/dynamic-configuration.md
+++ b/source/docs/getting-started/dynamic-configuration.md
@@ -37,7 +37,7 @@ the provisioner.  Since Kitchen 1.7.0 the log level for the provisioner is no lo
 ---
 provisioner:
   name: chef-zero
-  log_level: <%= ENV['CHEF_LOG_LEVEL'] || auto %>
+  log_level: <%= ENV['CHEF_LOG_LEVEL'] || "auto" %>
 ~~~
 
 You can also specify a path to a global `config.yml`, project or local `.kitchen.yml` file by setting the following environment variables:


### PR DESCRIPTION
The example for reading `CHEF_LOG_LEVEL` from an environment variable lacks quotes around the `auto`, as already mentioned [here](https://github.com/test-kitchen/kitchen-docs/pull/44/files#r67182368) by @vinyar.