### PR TITLE
Refreshed examples with kitchen 1.14.2, VB 5.1, ubuntu-14.04

### DIFF
--- a/source/docs/getting-started/adding-dependency.md
+++ b/source/docs/getting-started/adding-dependency.md
@@ -22,36 +22,52 @@ Note that we're adding a constraint on the version of the runit cookbook. While 
 Now, let's see if we get to pass our tests:
 
 ~~~
-$ kitchen verify server-ubuntu-1204
------> Starting Kitchen (v1.0.0)
------> Converging <server-ubuntu-1204>...
+$ kitchen verify server-ubuntu-1404
+-----> Starting Kitchen (v1.14.2)
+-----> Converging <server-ubuntu-1404>...
        Preparing files for transfer
+       Preparing dna.json
        Preparing current project directory as a cookbook
        Removing non-cookbook files before transfer
-       Transfering files to <server-ubuntu-1204>
-[2013-12-02T00:04:57+00:00] INFO: Forking chef instance to converge...
-Starting Chef Client, version 11.8.0
-[2013-12-02T00:04:57+00:00] INFO: *** Chef 11.8.0 ***
-[2013-12-02T00:04:57+00:00] INFO: Chef-client pid: 1462
-[2013-12-02T00:04:58+00:00] INFO: Setting the run_list to ["recipe[git::server]"] from JSON
-[2013-12-02T00:04:58+00:00] INFO: Run List is [recipe[git::server]]
-[2013-12-02T00:04:58+00:00] INFO: Run List expands to [git::server]
-[2013-12-02T00:04:58+00:00] INFO: Starting Chef Run for server-ubuntu-1204
-[2013-12-02T00:04:58+00:00] INFO: Running start handlers
-[2013-12-02T00:04:58+00:00] INFO: Start handlers complete.
-Compiling Cookbooks...
-[2013-12-02T00:04:58+00:00] ERROR: Running exception handlers
-[2013-12-02T00:04:58+00:00] ERROR: Exception handlers complete
-[2013-12-02T00:04:58+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
-Chef Client failed. 0 resources updated
-[2013-12-02T00:04:58+00:00] ERROR: Cookbook runit not found. If you're loading runit from another cookbook, make sure you configure the dependency in your metadata
-[2013-12-02T00:04:58+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
->>>>>> Converge failed on instance <server-ubuntu-1204>.
->>>>>> Please see .kitchen/logs/server-ubuntu-1204.log for more details
+       Preparing solo.rb
+-----> Chef Omnibus installation detected (install only if missing)
+       Transferring files to <server-ubuntu-1404>
+       Starting Chef Client, version 12.17.44
+       resolving cookbooks for run list: ["git::server"]
+
+       ================================================================================
+       Error Resolving Cookbooks for Run List:
+       ================================================================================
+
+       Missing Cookbooks:
+       ------------------
+       No such cookbook: runit
+
+       Expanded Run List:
+       ------------------
+       * git::server
+
+       Platform:
+       ---------
+       x86_64-linux
+
+
+       Running handlers:
+       [2016-12-18T15:49:01+00:00] ERROR: Running exception handlers
+       Running handlers complete
+       [2016-12-18T15:49:01+00:00] ERROR: Exception handlers complete
+       Chef Client failed. 0 resources updated in 01 seconds
+       [2016-12-18T15:49:01+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
+       [2016-12-18T15:49:01+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
+       [2016-12-18T15:49:01+00:00] ERROR: 412 "Precondition Failed"
+       [2016-12-18T15:49:01+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
 >>>>>> ------Exception-------
 >>>>>> Class: Kitchen::ActionFailed
->>>>>> Message: SSH exited (1) for command: [sudo -E chef-solo --config /tmp/kitchen/solo.rb --json-attributes /tmp/kitchen/dna.json  --log_level info]
+>>>>>> Message: 1 actions failed.
+>>>>>>     Converge failed on instance <server-ubuntu-1404>.  Please see .kitchen/logs/server-ubuntu-1404.log for more details
 >>>>>> ----------------------
+>>>>>> Please see .kitchen/logs/kitchen.log for more details
+>>>>>> Also try running `kitchen diagnose --all` for configuration
 ~~~
 
 Hmm, Chef still seems to be confused. We've told Chef that we depend on the runit cookbook yet it's still complaining about our metadata.
@@ -70,102 +86,83 @@ To get started we need to install the berkshelf gem--Test Kitchen doesn't depend
 
 ~~~
 $ gem install berkshelf
-Fetching: i18n-0.6.5.gem (100%)
-Successfully installed i18n-0.6.5
-Fetching: multi_json-1.8.2.gem (100%)
-Successfully installed multi_json-1.8.2
-Fetching: activesupport-3.2.15.gem (100%)
-Successfully installed activesupport-3.2.15
-Fetching: addressable-2.3.5.gem (100%)
-Successfully installed addressable-2.3.5
-Fetching: buff-ruby_engine-0.1.0.gem (100%)
-Successfully installed buff-ruby_engine-0.1.0
-Fetching: buff-shell_out-0.1.1.gem (100%)
-Successfully installed buff-shell_out-0.1.1
-Fetching: hashie-2.0.5.gem (100%)
-Successfully installed hashie-2.0.5
-Fetching: chozo-0.6.1.gem (100%)
-Successfully installed chozo-0.6.1
-Fetching: multipart-post-1.2.0.gem (100%)
-Successfully installed multipart-post-1.2.0
-Fetching: faraday-0.8.8.gem (100%)
-Successfully installed faraday-0.8.8
-Fetching: minitar-0.5.4.gem (100%)
-Successfully installed minitar-0.5.4
-Fetching: retryable-1.3.3.gem (100%)
-Successfully installed retryable-1.3.3
-Fetching: buff-extensions-0.5.0.gem (100%)
-Successfully installed buff-extensions-0.5.0
-Fetching: varia_model-0.2.0.gem (100%)
-Successfully installed varia_model-0.2.0
-Fetching: buff-config-0.4.0.gem (100%)
-Successfully installed buff-config-0.4.0
-Fetching: buff-ignore-1.1.1.gem (100%)
-Successfully installed buff-ignore-1.1.1
-Fetching: timers-1.1.0.gem (100%)
-Successfully installed timers-1.1.0
-Fetching: celluloid-0.14.1.gem (100%)
-Successfully installed celluloid-0.14.1
-Fetching: nio4r-0.5.0.gem (100%)
+Fetching: public_suffix-2.0.4.gem (100%)
+Successfully installed public_suffix-2.0.4
+Fetching: addressable-2.5.0.gem (100%)
+Successfully installed addressable-2.5.0
+Fetching: multipart-post-2.0.0.gem (100%)
+Successfully installed multipart-post-2.0.0
+Fetching: faraday-0.9.2.gem (100%)
+Successfully installed faraday-0.9.2
+Fetching: httpclient-2.8.3.gem (100%)
+Successfully installed httpclient-2.8.3
+Fetching: hashie-3.4.6.gem (100%)
+Successfully installed hashie-3.4.6
+Fetching: buff-extensions-2.0.0.gem (100%)
+Successfully installed buff-extensions-2.0.0
+Fetching: varia_model-0.6.0.gem (100%)
+Successfully installed varia_model-0.6.0
+Fetching: buff-config-2.0.0.gem (100%)
+Successfully installed buff-config-2.0.0
+Fetching: buff-ignore-1.2.0.gem (100%)
+Successfully installed buff-ignore-1.2.0
+Fetching: buff-ruby_engine-1.0.0.gem (100%)
+Successfully installed buff-ruby_engine-1.0.0
+Fetching: buff-shell_out-1.1.0.gem (100%)
+Successfully installed buff-shell_out-1.1.0
+Fetching: hitimes-1.2.4.gem (100%)
 Building native extensions.  This could take a while...
-Successfully installed nio4r-0.5.0
-Fetching: celluloid-io-0.14.1.gem (100%)
-Successfully installed celluloid-io-0.14.1
+Successfully installed hitimes-1.2.4
+Fetching: timers-4.0.4.gem (100%)
+Successfully installed timers-4.0.4
+Fetching: celluloid-0.16.0.gem (100%)
+Successfully installed celluloid-0.16.0
+Fetching: nio4r-1.2.1.gem (100%)
+Building native extensions.  This could take a while...
+Successfully installed nio4r-1.2.1
+Fetching: celluloid-io-0.16.2.gem (100%)
+Successfully installed celluloid-io-0.16.2
+Fetching: mixlib-shellout-2.2.7.gem (100%)
+Successfully installed mixlib-shellout-2.2.7
+Fetching: mixlib-config-2.2.4.gem (100%)
+Successfully installed mixlib-config-2.2.4
+Fetching: fuzzyurl-0.9.0.gem (100%)
+Successfully installed fuzzyurl-0.9.0
+Fetching: chef-config-12.17.44.gem (100%)
+Successfully installed chef-config-12.17.44
 Fetching: erubis-2.7.0.gem (100%)
 Successfully installed erubis-2.7.0
-Fetching: mixlib-log-1.6.0.gem (100%)
-Successfully installed mixlib-log-1.6.0
-Fetching: mixlib-authentication-1.3.0.gem (100%)
-Successfully installed mixlib-authentication-1.3.0
-Fetching: net-http-persistent-2.9.gem (100%)
-Successfully installed net-http-persistent-2.9
-Fetching: solve-0.8.2.gem (100%)
-Successfully installed solve-0.8.2
-Fetching: ffi-1.9.3.gem (100%)
-Building native extensions.  This could take a while...
-Successfully installed ffi-1.9.3
-Fetching: gssapi-1.0.3.gem (100%)
-Successfully installed gssapi-1.0.3
-Fetching: httpclient-2.3.4.1.gem (100%)
-Successfully installed httpclient-2.3.4.1
-Fetching: mini_portile-0.5.2.gem (100%)
-Successfully installed mini_portile-0.5.2
-Fetching: nokogiri-1.6.0.gem (100%)
-Building native extensions.  This could take a while...
-Successfully installed nokogiri-1.6.0
-Fetching: rubyntlm-0.1.1.gem (100%)
-Successfully installed rubyntlm-0.1.1
-Fetching: uuidtools-2.1.4.gem (100%)
-Successfully installed uuidtools-2.1.4
-Fetching: builder-3.2.2.gem (100%)
-Successfully installed builder-3.2.2
-Fetching: nori-1.1.5.gem (100%)
-Successfully installed nori-1.1.5
-Fetching: rack-1.5.2.gem (100%)
-Successfully installed rack-1.5.2
-Fetching: httpi-0.9.7.gem (100%)
-Successfully installed httpi-0.9.7
-Fetching: wasabi-1.0.0.gem (100%)
-Successfully installed wasabi-1.0.0
-Fetching: gyoku-1.1.0.gem (100%)
-Successfully installed gyoku-1.1.0
-Fetching: akami-1.2.0.gem (100%)
-Successfully installed akami-1.2.0
-Fetching: savon-0.9.5.gem (100%)
-Successfully installed savon-0.9.5
-Fetching: little-plugger-1.1.3.gem (100%)
-Successfully installed little-plugger-1.1.3
-Fetching: logging-1.8.1.gem (100%)
-Successfully installed logging-1.8.1
-Fetching: winrm-1.1.3.gem (100%)
-Successfully installed winrm-1.1.3
-Fetching: ridley-1.5.3.gem (100%)
-Successfully installed ridley-1.5.3
-Fetching: rbzip2-0.2.0.gem (100%)
-Successfully installed rbzip2-0.2.0
-Fetching: berkshelf-2.0.10.gem (100%)
-Successfully installed berkshelf-2.0.10
-46 gems installed
+Fetching: mixlib-log-1.7.1.gem (100%)
+Successfully installed mixlib-log-1.7.1
+Fetching: mixlib-authentication-1.4.1.gem (100%)
+Successfully installed mixlib-authentication-1.4.1
+Fetching: retryable-2.0.4.gem (100%)
+Successfully installed retryable-2.0.4
+Fetching: semverse-2.0.0.gem (100%)
+Successfully installed semverse-2.0.0
+Fetching: ridley-5.1.0.gem (100%)
+Successfully installed ridley-5.1.0
+Fetching: berkshelf-api-client-3.0.0.gem (100%)
+Successfully installed berkshelf-api-client-3.0.0
+Fetching: cleanroom-1.0.0.gem (100%)
+Successfully installed cleanroom-1.0.0
+Fetching: minitar-0.5.4.gem (100%)
+Successfully installed minitar-0.5.4
+Fetching: molinillo-0.5.4.gem (100%)
+Successfully installed molinillo-0.5.4
+Fetching: solve-3.1.0.gem (100%)
+Successfully installed solve-3.1.0
+Fetching: thor-0.19.1.gem (100%)
+Successfully installed thor-0.19.1
+Fetching: sawyer-0.8.1.gem (100%)
+Successfully installed sawyer-0.8.1
+Fetching: octokit-4.6.2.gem (100%)
+Successfully installed octokit-4.6.2
+Fetching: mixlib-archive-0.2.0.gem (100%)
+Successfully installed mixlib-archive-0.2.0
+Fetching: berkshelf-5.3.0.gem (100%)
+Successfully installed berkshelf-5.3.0
+37 gems installed
 ~~~
 
 Next we'll create the smallest `Berksfile`, using your editor of choice:
@@ -181,127 +178,124 @@ The `metadata` command tells Berkshelf that the current project is a Chef cookbo
 Now, let's re-run `kitchen verify`:
 
 ~~~
-$ kitchen verify server-ubuntu-1204
------> Starting Kitchen (v1.0.0)
------> Converging <server-ubuntu-1204>...
+$ kitchen verify server-ubuntu-1404
+-----> Starting Kitchen (v1.14.2)
+-----> Converging <server-ubuntu-1404>...
        Preparing files for transfer
-       Resolving cookbook dependencies with Berkshelf...
+       Preparing dna.json
+       Resolving cookbook dependencies with Berkshelf 5.3.0...
        Removing non-cookbook files before transfer
-       Transfering files to <server-ubuntu-1204>
-[2013-12-02T02:36:51+00:00] INFO: Forking chef instance to converge...
-Starting Chef Client, version 11.8.0
-[2013-12-02T02:36:51+00:00] INFO: *** Chef 11.8.0 ***
-[2013-12-02T02:36:51+00:00] INFO: Chef-client pid: 1621
-[2013-12-02T02:36:51+00:00] INFO: Setting the run_list to ["recipe[git::server]"] from JSON
-[2013-12-02T02:36:51+00:00] INFO: Run List is [recipe[git::server]]
-[2013-12-02T02:36:51+00:00] INFO: Run List expands to [git::server]
-[2013-12-02T02:36:51+00:00] INFO: Starting Chef Run for server-ubuntu-1204
-[2013-12-02T02:36:51+00:00] INFO: Running start handlers
-[2013-12-02T02:36:51+00:00] INFO: Start handlers complete.
-Compiling Cookbooks...
-Converging 9 resources
-Recipe: git::default
-  * package[git] action install[2013-12-02T02:36:51+00:00] INFO: Processing package[git] action install (git::default line 4)
+       Preparing solo.rb
+-----> Chef Omnibus installation detected (install only if missing)
+       Transferring files to <server-ubuntu-1404>
+       Starting Chef Client, version 12.17.44
+       resolving cookbooks for run list: ["git::server"]
+       Synchronizing Cookbooks:
+         - build-essential (7.0.2)
+         - git (0.1.0)
+         - runit (1.4.6)
+         - seven_zip (2.0.2)
+         - yum (2.4.4)
+         - mingw (1.2.4)
+         - compat_resource (12.16.2)
+         - windows (2.1.1)
+         - ohai (4.2.3)
+       Installing Cookbook Gems:
+       Compiling Cookbooks...
+       /tmp/kitchen/cache/cookbooks/yum/providers/repository.rb:114: warning: key :type is duplicated and overwritten on line 121
+       [2016-12-18T16:26:21+00:00] WARN: Chef::Provider::YumRepository already exists!  Cannot create deprecation class for LWRP provider yum_repository from cookbook yum
+       [2016-12-18T16:26:21+00:00] WARN: YumRepository already exists!  Deprecation class overwrites Custom resource yum_repository from cookbook yum
+       Converging 9 resources
+       Recipe: git::default
+         * apt_package[git] action install
+           - install version 1:1.9.1-1ubuntu0.3 of package git
+         * log[Well, that was too easy] action write
 
-    - install version 1:1.7.9.5-1 of package git
+       Recipe: runit::default
+         * service[runit] action nothing (skipped due to action :nothing)
+         * execute[start-runsvdir] action nothing (skipped due to action :nothing)
+         * execute[runit-hup-init] action nothing (skipped due to action :nothing)
+         * apt_package[runit] action install
+         Recipe: <Dynamically Defined Resource>
+           * cookbook_file[/tmp/kitchen/cache/preseed/runit/runit-2.1.1-6.2ubuntu3.seed] action create
+             - create new file /tmp/kitchen/cache/preseed/runit/runit-2.1.1-6.2ubuntu3.seed
+             - update content in file /tmp/kitchen/cache/preseed/runit/runit-2.1.1-6.2ubuntu3.seed from none to 9c6758
+             --- /tmp/kitchen/cache/preseed/runit/runit-2.1.1-6.2ubuntu3.seed	2016-12-18 16:26:29.812136180 +0000
+             +++ /tmp/kitchen/cache/preseed/runit/.chef-runit-220161218-11757-1t3qb1o.1.1-6.2ubuntu3.seed	2016-12-18 16:26:29.812136180 +0000
+             @@ -1 +1,2 @@
+             +runit   runit/signalinit        boolean true
+           - preseed package runit
+           - install version 2.1.1-6.2ubuntu3 of package runit
+       Recipe: runit::default
+         * execute[start-runsvdir] action nothing (skipped due to action :nothing)
+         * execute[runit-hup-init] action nothing (skipped due to action :nothing)
+       Recipe: git::server
+         * apt_package[git-daemon-run] action install
+           - install version 1:1.9.1-1ubuntu0.3 of package git-daemon-run
+       Recipe: <Dynamically Defined Resource>
+         * service[git-daemon] action nothing (skipped due to action :nothing)
+       Recipe: git::server
+         * runit_service[git-daemon] action enable
+         Recipe: <Dynamically Defined Resource>
+           * link[/etc/init.d/git-daemon] action create
+             - create symlink at /etc/init.d/git-daemon to /usr/bin/sv
+           - configure service runit_service[git-daemon]
 
-  * log[Well, that was too easy] action write[2013-12-02T02:37:08+00:00] INFO: Processing log[Well, that was too easy] action write (git::default line 7)
-[2013-12-02T02:37:08+00:00] INFO: Well, that was too easy
-
-
-Recipe: runit::default
-  * service[runit] action nothing[2013-12-02T02:37:08+00:00] INFO: Processing service[runit] action nothing (runit::default line 20)
- (skipped due to action :nothing)
-  * execute[start-runsvdir] action nothing[2013-12-02T02:37:08+00:00] INFO: Processing execute[start-runsvdir] action nothing (runit::default line 24)
- (skipped due to action :nothing)
-  * execute[runit-hup-init] action nothing[2013-12-02T02:37:08+00:00] INFO: Processing execute[runit-hup-init] action nothing (runit::default line 33)
- (skipped due to action :nothing)
-  * package[runit] action install[2013-12-02T02:37:08+00:00] INFO: Processing package[runit] action install (runit::default line 95)
-Recipe: <Dynamically Defined Resource>
-  * cookbook_file[/tmp/kitchen/cache/preseed/runit/runit-2.1.1-6.2ubuntu2.seed] action create[2013-12-02T02:37:08+00:00] INFO: Processing cookbook_file[/tmp/kitchen/cache/preseed/runit/runit-2.1.1-6.2ubuntu2.seed] action create (dynamically defined)
-[2013-12-02T02:37:08+00:00] INFO: cookbook_file[/tmp/kitchen/cache/preseed/runit/runit-2.1.1-6.2ubuntu2.seed] created file /tmp/kitchen/cache/preseed/runit/runit-2.1.1-6.2ubuntu2.seed
-
-    - create new file /tmp/kitchen/cache/preseed/runit/runit-2.1.1-6.2ubuntu2.seed[2013-12-02T02:37:08+00:00] INFO: cookbook_file[/tmp/kitchen/cache/preseed/runit/runit-2.1.1-6.2ubuntu2.seed] updated file contents /tmp/kitchen/cache/preseed/runit/runit-2.1.1-6.2ubuntu2.seed
-
-    - update content in file /tmp/kitchen/cache/preseed/runit/runit-2.1.1-6.2ubuntu2.seed from none to 9c6758
-        --- /tmp/kitchen/cache/preseed/runit/runit-2.1.1-6.2ubuntu2.seed        2013-12-02 02:37:08.627719079 +0000
-        +++ /tmp/.runit-2.1.1-6.2ubuntu2.seed20131202-1621-1hysxxf      2013-12-02 02:37:08.635723077 +0000
-        @@ -1 +1,2 @@
-        +runit   runit/signalinit        boolean true
-
-[2013-12-02T02:37:08+00:00] INFO: package[runit] pre-seeding package installation instructions
-
-    - preseed package runit
-    - install version 2.1.1-6.2ubuntu2 of package runit
-
-[2013-12-02T02:37:11+00:00] INFO: package[runit] sending nothing action to execute[start-runsvdir] (immediate)
-Recipe: runit::default
-  * execute[start-runsvdir] action nothing[2013-12-02T02:37:11+00:00] INFO: Processing execute[start-runsvdir] action nothing (runit::default line 24)
- (skipped due to action :nothing)
-[2013-12-02T02:37:11+00:00] INFO: package[runit] sending nothing action to execute[runit-hup-init] (immediate)
-  * execute[runit-hup-init] action nothing[2013-12-02T02:37:11+00:00] INFO: Processing execute[runit-hup-init] action nothing (runit::default line 33)
- (skipped due to action :nothing)
-Recipe: git::server
-  * package[git-daemon-run] action install[2013-12-02T02:37:11+00:00] INFO: Processing package[git-daemon-run] action install (git::server line 4)
-
-    - install version 1:1.7.9.5-1 of package git-daemon-run
-
-Recipe: <Dynamically Defined Resource>
-  * service[git-daemon] action nothing[2013-12-02T02:37:12+00:00] INFO: Processing service[git-daemon] action nothing (dynamically defined)
- (skipped due to action :nothing)
-Recipe: git::server
-  * runit_service[git-daemon] action enable[2013-12-02T02:37:12+00:00] INFO: Processing runit_service[git-daemon] action enable (git::server line 6)
-Recipe: <Dynamically Defined Resource>
-  * link[/etc/init.d/git-daemon] action create[2013-12-02T02:37:12+00:00] INFO: Processing link[/etc/init.d/git-daemon] action create (dynamically defined)
-[2013-12-02T02:37:12+00:00] INFO: link[/etc/init.d/git-daemon] created
-
-    - create symlink at /etc/init.d/git-daemon to /usr/bin/sv
-
-[2013-12-02T02:37:12+00:00] INFO: runit_service[git-daemon] configured
-
-    - configure service runit_service[git-daemon]
-
-[2013-12-02T02:37:12+00:00] INFO: Chef Run complete in 21.335525906 seconds
-[2013-12-02T02:37:12+00:00] INFO: Running report handlers
-[2013-12-02T02:37:12+00:00] INFO: Report handlers complete
-Chef Client finished, 7 resources updated
-       Finished converging <server-ubuntu-1204> (0m24.09s).
------> Setting up <server-ubuntu-1204>...
-Fetching: thor-0.18.1.gem (100%)
-Fetching: busser-0.6.0.gem (100%)
-Successfully installed thor-0.18.1
-Successfully installed busser-0.6.0
-2 gems installed
------> Setting up Busser
-       Creating BUSSER_ROOT in /tmp/busser
-       Creating busser binstub
-       Plugin serverspec installed (version 0.2.5)
+       Running handlers:
+       Running handlers complete
+       Chef Client finished, 7/13 resources updated in 14 seconds
+       Finished converging <server-ubuntu-1404> (0m19.57s).
+-----> Setting up <server-ubuntu-1404>...
+       Finished setting up <server-ubuntu-1404> (0m0.00s).
+-----> Verifying <server-ubuntu-1404>...
+       Preparing files for transfer
+-----> Installing Busser (busser)
+Fetching: thor-0.19.0.gem (100%)
+       Successfully installed thor-0.19.0
+Fetching: busser-0.7.1.gem (100%)
+       Successfully installed busser-0.7.1
+       2 gems installed
+       Installing Busser plugins: busser-serverspec
+       Plugin serverspec installed (version 0.5.10)
 -----> Running postinstall for serverspec plugin
-       Finished setting up <server-ubuntu-1204> (0m15.49s).
------> Verifying <server-ubuntu-1204>...
-       Suite path directory /tmp/busser/suites does not exist, skipping.
-Uploading /tmp/busser/suites/serverspec/git_daemon_spec.rb (mode=0644)
+       Suite path directory /tmp/verifier/suites does not exist, skipping.
+       Transferring files to <server-ubuntu-1404>
 -----> Running serverspec test suite
-/opt/chef/embedded/bin/ruby -I/tmp/busser/suites/serverspec -S /opt/chef/embedded/bin/rspec /tmp/busser/suites/serverspec/git_daemon_spec.rb --color --format documentation
+-----> Installing Serverspec..
+Fetching: diff-lcs-1.2.5.gem (100%)
+Fetching: rspec-expectations-3.5.0.gem (100%)
+Fetching: rspec-mocks-3.5.0.gem (100%)
+Fetching: rspec-3.5.0.gem (100%)
+Fetching: rspec-its-1.2.0.gem (100%)
+Fetching: multi_json-1.12.1.gem (100%)
+Fetching: net-ssh-3.2.0.gem (100%)
+Fetching: net-scp-1.2.1.gem (100%)
+Fetching: net-telnet-0.1.1.gem (100%)
+Fetching: sfl-2.3.gem (100%)
+Fetching: specinfra-2.66.3.gem (100%)
+Fetching: serverspec-2.37.2.gem (100%)
+-----> serverspec installed (version 2.37.2)
+       /opt/chef/embedded/bin/ruby -I/tmp/verifier/suites/serverspec -I/tmp/verifier/gems/gems/rspec-support-3.5.0/lib:/tmp/verifier/gems/gems/rspec-core-3.5.4/lib /opt/chef/embedded/bin/rspec --pattern /tmp/verifier/suites/serverspec/\*\*/\*_spec.rb --color --format documentation --default-path /tmp/verifier/suites/serverspec
 
-Git Daemon
-  is listening on port 9418
-  has a running service of git-daemon
+       Git Daemon
+         is listening on port 9418
+         has a running service of git-daemon
 
-Finished in 0.0344 seconds
-2 examples, 0 failures
-       Finished verifying <server-ubuntu-1204> (0m1.20s).
------> Kitchen is finished. (0m41.16s)
+       Finished in 0.09235 seconds (files took 0.24348 seconds to load)
+       2 examples, 0 failures
+
+       Finished verifying <server-ubuntu-1404> (0m15.04s).
+-----> Kitchen is finished. (0m35.07s)
 ~~~
 
-Awesome, and tests pass! Did you notice the `Resolving cookbook dependencies with Berkshelf...` line near the beginning? Confirming our success:
+Awesome, and tests pass! Did you notice the `Resolving cookbook dependencies with Berkshelf 5.3.0...` line near the beginning? Confirming our success:
 
 ~~~
 $ kitchen list server
-Instance            Driver   Provisioner  Last Action
-server-ubuntu-1204  Vagrant  ChefSolo     Verified
-server-ubuntu-1004  Vagrant  ChefSolo     <Not Created>
-server-centos-64    Vagrant  ChefSolo     <Not Created>
+Instance            Driver   Provisioner  Verifier  Transport  Last Action    Last Error
+server-ubuntu-1404  Vagrant  ChefSolo     Busser    Ssh        Verified       <None>
+server-ubuntu-1004  Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
+server-centos-72    Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
 ~~~
 
 Now let's backfill the other platforms.

--- a/source/docs/getting-started/adding-platform.md
+++ b/source/docs/getting-started/adding-platform.md
@@ -8,7 +8,7 @@ next:
   url: "dynamic-configuration"
 ---
 
-Now that we are masters of the Ubuntu platform, let's add support for CentOS to our cookbook. This shouldn't be too bad. Open `.kitchen.yml` in your editor and the `centos-6.4` line to your platforms list so that it resembles:
+Now that we are masters of the Ubuntu platform, let's add support for CentOS to our cookbook. This shouldn't be too bad. Open `.kitchen.yml` in your editor and the `centos-7.2` line to your platforms list so that it resembles:
 
 ~~~yaml
 ---
@@ -20,7 +20,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
-  - name: centos-6.4
+  - name: centos-7.2
 
 suites:
   - name: default
@@ -33,138 +33,169 @@ Now let's check the status of our instances:
 
 ~~~
 $ kitchen list
-Instance             Driver   Provisioner  Last Action
-default-ubuntu-1204  Vagrant  Chef Solo    <Not Created>
-default-centos-64    Vagrant  Chef Solo    <Not Created>
+Instance             Driver   Provisioner  Verifier  Transport  Last Action    Last Error
+default-ubuntu-1404  Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
+default-centos-72    Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
 ~~~
 
 We're going to use two shortcuts here in the next command:
 
 * Each Test Kitchen instance has a simple state machine that tracks where it is in its lifecyle. Given its current state and the desired state, the instance is smart enough to run all actions in between current and desired. In our next example we will take an instance from not created to verified in one command.
-* Any `kitchen` subcommand that takes an instance name as an argument can take a Ruby regular expression that will be used to glob a list of instances together. This means that `kitchen test ubuntu` would run the **test** action only the ubuntu instance. Note that the **list** subcommand also takes the regex-globbing argument so feel free to experiment there. In our next example we'll select the `default-centos-64` instance with simply `64`.
+* Any `kitchen` subcommand that takes an instance name as an argument can take a Ruby regular expression that will be used to glob a list of instances together. This means that `kitchen test ubuntu` would run the **test** action only the ubuntu instance. Note that the **list** subcommand also takes the regex-globbing argument so feel free to experiment there. In our next example we'll select the `default-centos-72` instance with simply `72`.
 
 Let's see how CentOS runs our cookbook:
 
 ~~~
-$ kitchen verify 64
------> Starting Kitchen (v1.0.0.beta.3)
------> Creating <default-centos-64>
-       [kitchen::driver::vagrant command] BEGIN (vagrant up --no-provision)
+$ kitchen destroy
+-----> Starting Kitchen (v1.14.2)
+-----> Destroying <default-ubuntu-1404>...
+       Finished destroying <default-ubuntu-1404> (0m0.00s).
+-----> Destroying <default-centos-72>...
+       ==> default: Forcing shutdown of VM...
+       ==> default: Destroying VM and associated drives...
+       Vagrant instance <default-centos-72> destroyed.
+       Finished destroying <default-centos-72> (0m6.46s).
+-----> Kitchen is finished. (0m6.74s)
+thoth:git-cookbook dom$ kitchen verify 72
+-----> Starting Kitchen (v1.14.2)
+-----> Creating <default-centos-72>...
        Bringing machine 'default' up with 'virtualbox' provider...
-       [default] Importing base box 'opscode-centos-6.4'...
-       [default] Matching MAC address for NAT networking...
-       [default] Setting the name of the VM...
-       [default] Clearing any previously set forwarded ports...
-       [default] Creating shared folders metadata...
-       [default] Clearing any previously set network interfaces...
-       [default] Preparing network interfaces based on configuration...
-       [default] Forwarding ports...
-       [default] -- 22 => 2222 (adapter 1)
-       [default] Running 'pre-boot' VM customizations...
-       [default] Booting VM...
-       [default] Waiting for machine to boot. This may take a few minutes...
-       [default] Machine booted and ready!
-       [default] Setting hostname...
-       [default] Mounting shared folders...
-       [kitchen::driver::vagrant command] END (0m51.59s)
-       [kitchen::driver::vagrant command] BEGIN (vagrant ssh-config)
-       [kitchen::driver::vagrant command] END (0m0.87s)
-       Vagrant instance <default-centos-64> created.
-       Finished creating <default-centos-64> (0m57.25s).
------> Converging <default-centos-64>
------> Installing Chef Omnibus (true)
-       --2013-10-17 06:52:15--  https://www.opscode.com/chef/install.sh
-Resolving www.opscode.com...        184.106.28.82
-       Connecting to www.opscode.com|184.106.28.82|:443...
-       connected.
-HTTP request sent, awaiting response...        200 OK
-       Length: 6790 (6.6K) [application/x-sh]
-       Saving to: `STDOUT'
-
- 0% [                                       ] 0           --.-K/s
-100%[======================================>] 6,790       --.-K/s   in 0s
-
-       2013-10-17 06:52:20 (336 MB/s) - written to stdout [6790/6790]
-
-       Downloading Chef  for el...
-       Installing Chef
-       warning: /tmp/tmp.VHOrEPIv/chef-.x86_64.rpm: Header V4 DSA/SHA1 Signature, key ID 83ef826a: NOKEY
-Preparing...                #####  ########################################### [100%]
-   1:chef                          ########################################### [100%]
-       Thank you for installing Chef!
+       ==> default: Importing base box 'bento/centos-7.2'...
+==> default: Matching MAC address for NAT networking...
+       ==> default: Checking if box 'bento/centos-7.2' is up to date...
+       ==> default: Setting the name of the VM: kitchen-git-cookbook-default-centos-72_default_1482061251204_56474
+       ==> default: Clearing any previously set network interfaces...
+       ==> default: Preparing network interfaces based on configuration...
+           default: Adapter 1: nat
+       ==> default: Forwarding ports...
+           default: 22 (guest) => 2222 (host) (adapter 1)
+       ==> default: Running 'pre-boot' VM customizations...
+       ==> default: Booting VM...
+       ==> default: Waiting for machine to boot. This may take a few minutes...
+           default: SSH address: 127.0.0.1:2222
+           default: SSH username: vagrant
+           default: SSH auth method: private key
+           default: Warning: Remote connection disconnect. Retrying...
+           default:
+           default: Vagrant insecure key detected. Vagrant will automatically replace
+           default: this with a newly generated keypair for better security.
+           default:
+           default: Inserting generated public key within guest...
+           default: Removing insecure key from the guest if it's present...
+           default: Key inserted! Disconnecting and reconnecting using new SSH key...
+       ==> default: Machine booted and ready!
+       ==> default: Checking for guest additions in VM...
+       ==> default: Setting hostname...
+       ==> default: Mounting shared folders...
+           default: /tmp/omnibus/cache => /Users/dom/.kitchen/cache
+       ==> default: Machine not provisioned because `--no-provision` is specified.
+       /etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
+       [SSH] Established
+       Vagrant instance <default-centos-72> created.
+       Finished creating <default-centos-72> (0m52.92s).
+-----> Converging <default-centos-72>...
+       Preparing files for transfer
+       Preparing dna.json
        Preparing current project directory as a cookbook
-       Removing non-cookbook files in sandbox
-       Uploaded /var/folders/ld/ykg04kvx5y53v7qkhpp254y40000gn/T/default-centos-64-sandbox-20131017-65316-1copg0l/cookbooks/git/metadata.rb (27 bytes)
-       Uploaded /var/folders/ld/ykg04kvx5y53v7qkhpp254y40000gn/T/default-centos-64-sandbox-20131017-65316-1copg0l/cookbooks/git/recipes/default.rb (45 bytes)
-       Uploaded /var/folders/ld/ykg04kvx5y53v7qkhpp254y40000gn/T/default-centos-64-sandbox-20131017-65316-1copg0l/dna.json (28 bytes)
-       Uploaded /var/folders/ld/ykg04kvx5y53v7qkhpp254y40000gn/T/default-centos-64-sandbox-20131017-65316-1copg0l/solo.rb (166 bytes)
-       [2013-10-17T06:53:02+00:00] INFO: Forking chef instance to converge...
-       Starting Chef Client, version 11.6.2
-       [2013-10-17T06:53:02+00:00] INFO: *** Chef 11.6.2 ***
-       [2013-10-17T06:53:02+00:00] INFO: Setting the run_list to ["recipe[git]"] from JSON
-       [2013-10-17T06:53:02+00:00] INFO: Run List is [recipe[git]]
-       [2013-10-17T06:53:02+00:00] INFO: Run List expands to [git]
-       [2013-10-17T06:53:02+00:00] INFO: Starting Chef Run for default-centos-64
-       [2013-10-17T06:53:02+00:00] INFO: Running start handlers
-       [2013-10-17T06:53:02+00:00] INFO: Start handlers complete.
+       Removing non-cookbook files before transfer
+       Preparing solo.rb
+       /etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
+-----> Installing Chef Omnibus (install only if missing)
+       Downloading https://omnitruck.chef.io/install.sh to file /tmp/install.sh
+       Trying wget...
+       Download complete.
+       el 7 x86_64
+       Getting information for chef stable  for el...
+       downloading https://omnitruck.chef.io/stable/chef/metadata?v=&p=el&pv=7&m=x86_64
+         to file /tmp/install.sh.9748/metadata.txt
+       trying wget...
+       sha1	ffa2c60116d57c8b987ee2e906bff9106c98daf5
+       sha256	beccc11f5861bde369f62ca3fd7361b536786e91d73f538857e625a622f8caef
+       url	https://packages.chef.io/files/stable/chef/12.17.44/el/7/chef-12.17.44-1.el7.x86_64.rpm
+       version	12.17.44
+       downloaded metadata file looks valid...
+       /tmp/omnibus/cache/chef-12.17.44-1.el7.x86_64.rpm already exists, verifiying checksum...
+       Comparing checksum with sha256sum...
+       checksum compare succeeded, using existing file!
+
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+
+       You are installing an omnibus package without a version pin.  If you are installing
+       on production servers via an automated process this is DANGEROUS and you will
+       be upgraded without warning on new releases, even to new major releases.
+       Letting the version float is only appropriate in desktop, test, development or
+       CI/CD environments.
+
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+
+       Installing chef
+       installing with rpm...
+       warning: /tmp/omnibus/cache/chef-12.17.44-1.el7.x86_64.rpm: Header V4 DSA/SHA1 Signature, key ID 83ef826a: NOKEY
+       Preparing...                          ################################# [100%]
+       Updating / installing...
+          1:chef-12.17.44-1.el7              ################################# [100%]
+       Thank you for installing Chef!
+       /etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
+       Transferring files to <default-centos-72>
+       /etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
+       Starting Chef Client, version 12.17.44
+       Creating a new client identity for default-centos-72 using the validator key.
+       resolving cookbooks for run list: ["git::default"]
+       Synchronizing Cookbooks:
+         - git (0.1.0)
+       Installing Cookbook Gems:
        Compiling Cookbooks...
        Converging 2 resources
        Recipe: git::default
-         * package[git] action install
-
-       [2013-10-17T06:53:02+00:00] INFO: Processing package[git] action install (git::default line 1)
-        (up to date)
+         * yum_package[git] action install
+           - install version 1.8.3.1-6.el7_2.1 of package git
          * log[Well, that was too easy] action write
-       [2013-10-17T06:54:05+00:00] INFO: Processing log[Well, that was too easy] action write (git::default line 3)
-       [2013-10-17T06:54:05+00:00] INFO: Well, that was too easy
 
 
-       [2013-10-17T06:54:05+00:00] INFO: Chef Run complete in 62.525344754 seconds
-       [2013-10-17T06:54:05+00:00] INFO: Running report handlers
-       [2013-10-17T06:54:05+00:00] INFO: Report handlers complete
-       Chef Client finished, 1 resources updated
-       Finished converging <default-centos-64> (1m50.16s).
------> Setting up <default-centos-64>
-Fetching: thor-0.18.1.gem (100%)
-Fetching: busser-0.4.1.gem (100%)
-       Successfully installed thor-0.18.1
-       Successfully installed busser-0.4.1
+       Running handlers:
+       Running handlers complete
+       Chef Client finished, 2/2 resources updated in 32 seconds
+       Finished converging <default-centos-72> (0m44.40s).
+-----> Setting up <default-centos-72>...
+       Finished setting up <default-centos-72> (0m0.00s).
+-----> Verifying <default-centos-72>...
+       Preparing files for transfer
+       /etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
+-----> Installing Busser (busser)
+Fetching: thor-0.19.0.gem (100%)
+       Successfully installed thor-0.19.0
+Fetching: busser-0.7.1.gem (100%)
+       Successfully installed busser-0.7.1
        2 gems installed
------> Setting up Busser
-       Creating BUSSER_ROOT in /opt/busser
-       Creating busser binstub
-       Plugin bats installed (version 0.1.0)
+       Installing Busser plugins: busser-bats
+       Plugin bats installed (version 0.3.0)
 -----> Running postinstall for bats plugin
-             create  /tmp/bats20131017-2604-10io6m5/bats
-             create  /tmp/bats20131017-2604-10io6m5/bats.tar.gz
-       Installed Bats to /opt/busser/vendor/bats/bin/bats
-             remove  /tmp/bats20131017-2604-10io6m5
-       Finished setting up <default-centos-64> (0m54.66s).
------> Verifying <default-centos-64>
-       Suite path directory /opt/busser/suites does not exist, skipping.
-       Uploading /opt/busser/suites/bats/git_installed.bats (mode=0644)
+       Installed Bats to /tmp/verifier/vendor/bats/bin/bats
+       /etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
+       Suite path directory /tmp/verifier/suites does not exist, skipping.
+       Transferring files to <default-centos-72>
+       /etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
 -----> Running bats test suite
-       1..1
-       ok 1 git binary is found in PATH
-       Finished verifying <default-centos-64> (0m1.11s).
------> Kitchen is finished. (3m43.47s)
+ ✓ git binary is found in PATH
+
+       1 test, 0 failures
+       Finished verifying <default-centos-72> (0m5.49s).
+-----> Kitchen is finished. (1m42.99s)
 ~~~
 
-Nice! We've verified that our cookbook works on Ubuntu 12.04 and CentOS 6.4. Since the CentOS instance will hang out for no good reason, let's kill it for now:
+Nice! We've verified that our cookbook works on Ubuntu 14.04 and CentOS 7.2. Since the CentOS instance will hang out for no good reason, let's kill it for now:
 
 ~~~
 $ kitchen destroy
------> Starting Kitchen (v1.0.0.beta.3)
------> Destroying <default-ubuntu-1204>
-       Finished destroying <default-ubuntu-1204> (0m0.00s).
------> Destroying <default-centos-64>
-       [kitchen::driver::vagrant command] BEGIN (vagrant destroy -f)
-       [default] Forcing shutdown of VM...
-       [default] Destroying VM and associated drives...
-       [kitchen::driver::vagrant command] END (0m2.79s)
-       Vagrant instance <default-centos-64> destroyed.
-       Finished destroying <default-centos-64> (0m3.09s).
------> Kitchen is finished. (0m3.39s)
+-----> Starting Kitchen (v1.14.2)
+-----> Destroying <default-ubuntu-1404>...
+       Finished destroying <default-ubuntu-1404> (0m0.00s).
+-----> Destroying <default-centos-72>...
+       ==> default: Forcing shutdown of VM...
+       ==> default: Destroying VM and associated drives...
+       Vagrant instance <default-centos-72> destroyed.
+       Finished destroying <default-centos-72> (0m7.19s).
+-----> Kitchen is finished. (0m7.52s)
 ~~~
 
 Interesting. Test Kitchen tried to destroy both instances, one that was created and the other that was not. Which brings us to another tip with the `kitchen` command:
@@ -175,16 +206,16 @@ Let's make sure everything has been destroyed:
 
 ~~~
 $ kitchen list
-Instance             Driver   Provisioner  Last Action
-default-ubuntu-1204  Vagrant  Chef Solo    <Not Created>
-default-centos-64    Vagrant  Chef Solo    <Not Created>
+Instance             Driver   Provisioner  Verifier  Transport  Last Action    Last Error
+default-ubuntu-1404  Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
+default-centos-72    Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
 ~~~
 
 There's no production code change so far but we did modify the `.kitchen.yml` file, so let's commit that:
 
 ~~~
 $ git add .kitchen.yml
-> git commit -m "Add support for CentOS 6.4."
-[master 528ac72] Add support for CentOS 6.4.
+$ git commit -m "Add support for CentOS 7.2."
+[master f03cff6] Add support for CentOS 7.2.
  1 file changed, 1 insertion(+)
 ~~~

--- a/source/docs/getting-started/adding-suite.md
+++ b/source/docs/getting-started/adding-suite.md
@@ -38,13 +38,13 @@ Now run `kitchen list` to see our new suite in action:
 
 ~~~
 $ kitchen list
-Instance             Driver   Provisioner  Last Action
-default-ubuntu-1204  Vagrant  ChefSolo     <Not Created>
-default-ubuntu-1004  Vagrant  ChefSolo     <Not Created>
-default-centos-64    Vagrant  ChefSolo     <Not Created>
-server-ubuntu-1204   Vagrant  ChefSolo     <Not Created>
-server-ubuntu-1004   Vagrant  ChefSolo     <Not Created>
-server-centos-64     Vagrant  ChefSolo     <Not Created>
+Instance             Driver   Provisioner  Verifier  Transport  Last Action    Last Error
+default-ubuntu-1404  Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
+default-ubuntu-1004  Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
+default-centos-72    Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
+server-ubuntu-1404   Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
+server-ubuntu-1004   Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
+server-centos-72     Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
 ~~~
 
 Woah, we've doubled our number of instances! Yes, that is going to happen. This explosion of test cases is just one reason why testing is hard.

--- a/source/docs/getting-started/backfilling-platforms.md
+++ b/source/docs/getting-started/backfilling-platforms.md
@@ -12,150 +12,182 @@ Let's see if our server recipe works on the older Ubuntu 10.04 platform. Fingers
 
 ~~~
 $ kitchen verify server-ubuntu-1004
------> Starting Kitchen (v1.0.0)
+-----> Starting Kitchen (v1.14.2)
 -----> Creating <server-ubuntu-1004>...
        Bringing machine 'default' up with 'virtualbox' provider...
-       [default] Importing base box 'opscode-ubuntu-10.04'...
-       [default] Matching MAC address for NAT networking...
-       [default] Setting the name of the VM...
-       [default] Clearing any previously set forwarded ports...
-       [default] Fixed port collision for 22 => 2222. Now on port 2200.
-       [default] Creating shared folders metadata...
-       [default] Clearing any previously set network interfaces...
-       [default] Preparing network interfaces based on configuration...
-       [default] Forwarding ports...
-       [default] -- 22 => 2200 (adapter 1)
-       [default] Running 'pre-boot' VM customizations...
-       [default] Booting VM...
-       [default] Waiting for machine to boot. This may take a few minutes...
-       [default] Machine booted and ready!
-       [default] Setting hostname...
-       [default] Mounting shared folders...
+       ==> default: Importing base box 'bento/ubuntu-10.04'...
+==> default: Matching MAC address for NAT networking...
+       ==> default: Checking if box 'bento/ubuntu-10.04' is up to date...
+       ==> default: Setting the name of the VM: kitchen-git-cookbook-server-ubuntu-1004_default_1482078595260_53152
+       ==> default: Fixed port collision for 22 => 2222. Now on port 2200.
+       ==> default: Clearing any previously set network interfaces...
+       ==> default: Preparing network interfaces based on configuration...
+           default: Adapter 1: nat
+       ==> default: Forwarding ports...
+           default: 22 (guest) => 2200 (host) (adapter 1)
+       ==> default: Running 'pre-boot' VM customizations...
+       ==> default: Booting VM...
+       ==> default: Waiting for machine to boot. This may take a few minutes...
+           default: SSH address: 127.0.0.1:2200
+           default: SSH username: vagrant
+           default: SSH auth method: private key
+           default:
+           default: Vagrant insecure key detected. Vagrant will automatically replace
+           default: this with a newly generated keypair for better security.
+           default:
+           default: Inserting generated public key within guest...
+           default: Removing insecure key from the guest if it's present...
+           default: Key inserted! Disconnecting and reconnecting using new SSH key...
+       ==> default: Machine booted and ready!
+       ==> default: Checking for guest additions in VM...
+           default: The guest additions on this VM do not match the installed version of
+           default: VirtualBox! In most cases this is fine, but in rare cases it can
+           default: prevent things such as shared folders from working properly. If you see
+           default: shared folder errors, please make sure the guest additions within the
+           default: virtual machine match the version of VirtualBox you have installed on
+           default: your host and reload your VM.
+           default:
+           default: Guest Additions Version: 5.0.12
+           default: VirtualBox Version: 5.1
+       ==> default: Setting hostname...
+       ==> default: Mounting shared folders...
+           default: /tmp/omnibus/cache => /Users/dom/.kitchen/cache
+       ==> default: Machine not provisioned because `--no-provision` is specified.
+       [SSH] Established
        Vagrant instance <server-ubuntu-1004> created.
-       Finished creating <server-ubuntu-1004> (0m50.83s).
+       Finished creating <server-ubuntu-1004> (0m29.47s).
 -----> Converging <server-ubuntu-1004>...
        Preparing files for transfer
-       Resolving cookbook dependencies with Berkshelf...
+       Preparing dna.json
+       Resolving cookbook dependencies with Berkshelf 5.3.0...
        Removing non-cookbook files before transfer
------> Installing Chef Omnibus (true)
-       downloading https://www.opscode.com/chef/install.sh
-         to file /tmp/install.sh
+       Preparing solo.rb
+-----> Installing Chef Omnibus (install only if missing)
+       Downloading https://omnitruck.chef.io/install.sh to file /tmp/install.sh
+       Trying wget...
+       Trying python...
+       Download complete.
+       ubuntu 10.04 x86_64
+       Getting information for chef stable  for ubuntu...
+       downloading https://omnitruck.chef.io/stable/chef/metadata?v=&p=ubuntu&pv=10.04&m=x86_64
+         to file /tmp/install.sh.940/metadata.txt
        trying wget...
-       Downloading Chef  for ubuntu...
-       Installing Chef
+       trying perl...
+       trying python...
+       sha1	7d30b300f95f00036919ee8bf3b95ab73429e57e
+       sha256	663d6c42c90bbb9463bc02a7c5d777f7aa6ebd52c071a0c1963bc8c4db76dea2
+       url	https://packages.chef.io/files/stable/chef/12.10.24/ubuntu/10.04/chef_12.10.24-1_amd64.deb
+       version	12.10.24
+       downloaded metadata file looks valid...
+       /tmp/omnibus/cache/chef_12.10.24-1_amd64.deb already exists, verifiying checksum...
+       Comparing checksum with sha256sum...
+       checksum compare succeeded, using existing file!
+
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+
+       You are installing an omnibus package without a version pin.  If you are installing
+       on production servers via an automated process this is DANGEROUS and you will
+       be upgraded without warning on new releases, even to new major releases.
+       Letting the version float is only appropriate in desktop, test, development or
+       CI/CD environments.
+
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+
+       Installing chef
+       installing with dpkg...
        Selecting previously deselected package chef.
-       (Reading database ...
-(Reading database ... 44103 files and directories currently installed.)
-       Unpacking chef (from .../tmp.g6F0KqZE/chef__amd64.deb) ...
-       Setting up chef (11.8.0-1.ubuntu.10.04) ...
+(Reading database ... 21183 files and directories currently installed.)
+       Unpacking chef (from .../chef_12.10.24-1_amd64.deb) ...
+       Setting up chef (12.10.24-1) ...
        Thank you for installing Chef!
 
-       Transfering files to <server-ubuntu-1004>
-       [2013-12-02T02:44:11+00:00] INFO: Forking chef instance to converge...
-       Starting Chef Client, version 11.8.0
-       [2013-12-02T02:44:11+00:00] INFO: *** Chef 11.8.0 ***
-       [2013-12-02T02:44:11+00:00] INFO: Chef-client pid: 968
-       [2013-12-02T02:44:11+00:00] INFO: Setting the run_list to ["recipe[git::server]"] from JSON
-       [2013-12-02T02:44:11+00:00] INFO: Run List is [recipe[git::server]]
-       [2013-12-02T02:44:11+00:00] INFO: Run List expands to [git::server]
-       [2013-12-02T02:44:11+00:00] INFO: Starting Chef Run for server-ubuntu-1004
-       [2013-12-02T02:44:11+00:00] INFO: Running start handlers
-       [2013-12-02T02:44:11+00:00] INFO: Start handlers complete.
+       Transferring files to <server-ubuntu-1004>
+       Starting Chef Client, version 12.10.24
+       Installing Cookbook Gems:
        Compiling Cookbooks...
-       Converging 9 resources
+       [2016-12-18T16:30:30+00:00] WARN: Chef::Provider::AptRepository already exists!  Cannot create deprecation class for LWRP provider apt_repository from cookbook apt
+       [2016-12-18T16:30:30+00:00] WARN: AptRepository already exists!  Deprecation class overwrites Custom resource apt_repository from cookbook apt
+       Converging 17 resources
        Recipe: git::default
-         * package[git-core] action install[2013-12-02T02:44:11+00:00] INFO: Processing package[git-core] action install (git::default line 2)
-
+         * apt_package[git-core] action install
            - install version 1:1.7.0.4-1ubuntu0.2 of package git-core
-
-         * log[Well, that was too easy] action write[2013-12-02T02:44:24+00:00] INFO: Processing log[Well, that was too easy] action write (git::default line 7)
-       [2013-12-02T02:44:24+00:00] INFO: Well, that was too easy
-
+         * log[Well, that was too easy] action write
 
        Recipe: runit::default
-         * service[runit] action nothing[2013-12-02T02:44:24+00:00] INFO: Processing service[runit] action nothing (runit::default line 20)
-        (skipped due to action :nothing)
-         * execute[start-runsvdir] action nothing[2013-12-02T02:44:24+00:00] INFO: Processing execute[start-runsvdir] action nothing (runit::default line 24)
-        (skipped due to action :nothing)
-         * execute[runit-hup-init] action nothing[2013-12-02T02:44:24+00:00] INFO: Processing execute[runit-hup-init] action nothing (runit::default line 33)
-        (skipped due to action :nothing)
-         * package[runit] action install[2013-12-02T02:44:24+00:00] INFO: Processing package[runit] action install (runit::default line 95)
-       Recipe: <Dynamically Defined Resource>
-         * cookbook_file[/tmp/kitchen/cache/preseed/runit/runit-2.0.0-1ubuntu4.seed] action create[2013-12-02T02:44:25+00:00] INFO: Processing cookbook_file[/tmp/kitchen/cache/preseed/runit/runit-2.0.0-1ubuntu4.seed] action create (dynamically defined)
-       [2013-12-02T02:44:25+00:00] INFO: cookbook_file[/tmp/kitchen/cache/preseed/runit/runit-2.0.0-1ubuntu4.seed] created file /tmp/kitchen/cache/preseed/runit/runit-2.0.0-1ubuntu4.seed
-
-           - create new file /tmp/kitchen/cache/preseed/runit/runit-2.0.0-1ubuntu4.seed[2013-12-02T02:44:25+00:00] INFO: cookbook_file[/tmp/kitchen/cache/preseed/runit/runit-2.0.0-1ubuntu4.seed] updated file contents /tmp/kitchen/cache/preseed/runit/runit-2.0.0-1ubuntu4.seed
-
-           - update content in file /tmp/kitchen/cache/preseed/runit/runit-2.0.0-1ubuntu4.seed from none to 9c6758
-        --- /tmp/kitchen/cache/preseed/runit/runit-2.0.0-1ubuntu4.seed  2013-12-02 02:44:25.030657115 +0000
-        +++ /tmp/.runit-2.0.0-1ubuntu4.seed20131202-968-79dchx  2013-12-02 02:44:25.030657115 +0000
-        @@ -1 +1,2 @@
-        +runit   runit/signalinit        boolean true
-
-       [2013-12-02T02:44:25+00:00] INFO: package[runit] pre-seeding package installation instructions
-
+         * service[runit] action nothing (skipped due to action :nothing)
+         * execute[start-runsvdir] action nothing (skipped due to action :nothing)
+         * execute[runit-hup-init] action nothing (skipped due to action :nothing)
+         * apt_package[runit] action install
+         Recipe: <Dynamically Defined Resource>
+           * cookbook_file[/tmp/kitchen/cache/preseed/runit/runit-2.0.0-1ubuntu4.seed] action create
+             - create new file /tmp/kitchen/cache/preseed/runit/runit-2.0.0-1ubuntu4.seed
+             - update content in file /tmp/kitchen/cache/preseed/runit/runit-2.0.0-1ubuntu4.seed from none to 9c6758
+             --- /tmp/kitchen/cache/preseed/runit/runit-2.0.0-1ubuntu4.seed	2016-12-18 16:31:08.274826038 +0000
+             +++ /tmp/kitchen/cache/preseed/runit/.chef-runit-2.0.0-1ubuntu4.seed20161218-1029-1lv87tf	2016-12-18 16:31:08.274826038 +0000
+             @@ -1 +1,2 @@
+             +runit   runit/signalinit        boolean true
            - preseed package runit
-
            - install version 2.0.0-1ubuntu4 of package runit
-
-       [2013-12-02T02:44:26+00:00] INFO: package[runit] sending nothing action to execute[start-runsvdir] (immediate)
        Recipe: runit::default
-         * execute[start-runsvdir] action nothing[2013-12-02T02:44:26+00:00] INFO: Processing execute[start-runsvdir] action nothing (runit::default line 24)
-        (skipped due to action :nothing)
-       [2013-12-02T02:44:26+00:00] INFO: package[runit] sending nothing action to execute[runit-hup-init] (immediate)
-         * execute[runit-hup-init] action nothing[2013-12-02T02:44:26+00:00] INFO: Processing execute[runit-hup-init] action nothing (runit::default line 33)
-        (skipped due to action :nothing)
+         * execute[start-runsvdir] action nothing (skipped due to action :nothing)
+         * execute[runit-hup-init] action nothing (skipped due to action :nothing)
        Recipe: git::server
-         * package[git-daemon-run] action install[2013-12-02T02:44:26+00:00] INFO: Processing package[git-daemon-run] action install (git::server line 4)
-
+         * apt_package[git-daemon-run] action install
            - install version 1:1.7.0.4-1ubuntu0.2 of package git-daemon-run
-
        Recipe: <Dynamically Defined Resource>
-         * service[git-daemon] action nothing[2013-12-02T02:44:29+00:00] INFO: Processing service[git-daemon] action nothing (dynamically defined)
-        (skipped due to action :nothing)
+         * service[git-daemon] action nothing (skipped due to action :nothing)
        Recipe: git::server
-         * runit_service[git-daemon] action enable[2013-12-02T02:44:29+00:00] INFO: Processing runit_service[git-daemon] action enable (git::server line 6)
-       Recipe: <Dynamically Defined Resource>
-         * link[/etc/init.d/git-daemon] action create[2013-12-02T02:44:29+00:00] INFO: Processing link[/etc/init.d/git-daemon] action create (dynamically defined)
-       [2013-12-02T02:44:29+00:00] INFO: link[/etc/init.d/git-daemon] created
-
-           - create symlink at /etc/init.d/git-daemon to /usr/bin/sv
-
-       [2013-12-02T02:44:29+00:00] INFO: runit_service[git-daemon] configured
-
+         * runit_service[git-daemon] action enable
+         Recipe: <Dynamically Defined Resource>
+           * link[/etc/init.d/git-daemon] action create
+             - create symlink at /etc/init.d/git-daemon to /usr/bin/sv
            - configure service runit_service[git-daemon]
 
-       [2013-12-02T02:44:29+00:00] INFO: Chef Run complete in 17.598448178 seconds
-       [2013-12-02T02:44:29+00:00] INFO: Running report handlers
-       [2013-12-02T02:44:29+00:00] INFO: Report handlers complete
-       Chef Client finished, 7 resources updated
-       Finished converging <server-ubuntu-1004> (0m51.11s).
+       Running handlers:
+       Running handlers complete
+       Chef Client finished, 13/25 resources updated in 42 seconds
+       Finished converging <server-ubuntu-1004> (0m54.92s).
 -----> Setting up <server-ubuntu-1004>...
-Fetching: thor-0.18.1.gem (100%)
-Fetching: busser-0.6.0.gem (100%)
-       Successfully installed thor-0.18.1
-       Successfully installed busser-0.6.0
-       2 gems installed
------> Setting up Busser
-       Creating BUSSER_ROOT in /tmp/busser
-       Creating busser binstub
-       Plugin serverspec installed (version 0.2.5)
------> Running postinstall for serverspec plugin
-       Finished setting up <server-ubuntu-1004> (0m14.07s).
+       Finished setting up <server-ubuntu-1004> (0m0.00s).
 -----> Verifying <server-ubuntu-1004>...
-       Suite path directory /tmp/busser/suites does not exist, skipping.
-       Uploading /tmp/busser/suites/serverspec/git_daemon_spec.rb (mode=0644)
+       Preparing files for transfer
+-----> Installing Busser (busser)
+Fetching: thor-0.19.0.gem (100%)
+       Successfully installed thor-0.19.0
+Fetching: busser-0.7.1.gem (100%)
+       Successfully installed busser-0.7.1
+       2 gems installed
+       Installing Busser plugins: busser-serverspec
+       Plugin serverspec installed (version 0.5.10)
+-----> Running postinstall for serverspec plugin
+       Suite path directory /tmp/verifier/suites does not exist, skipping.
+       Transferring files to <server-ubuntu-1004>
 -----> Running serverspec test suite
-       /opt/chef/embedded/bin/ruby -I/tmp/busser/suites/serverspec -S /opt/chef/embedded/bin/rspec /tmp/busser/suites/serverspec/git_daemon_spec.rb --color --format documentation
+-----> Installing Serverspec..
+Fetching: diff-lcs-1.2.5.gem (100%)
+Fetching: rspec-expectations-3.5.0.gem (100%)
+Fetching: rspec-mocks-3.5.0.gem (100%)
+Fetching: rspec-3.5.0.gem (100%)
+Fetching: rspec-its-1.2.0.gem (100%)
+Fetching: multi_json-1.12.1.gem (100%)
+Fetching: net-ssh-3.2.0.gem (100%)
+Fetching: net-scp-1.2.1.gem (100%)
+Fetching: net-telnet-0.1.1.gem (100%)
+Fetching: sfl-2.3.gem (100%)
+Fetching: specinfra-2.66.3.gem (100%)
+Fetching: serverspec-2.37.2.gem (100%)
+-----> serverspec installed (version 2.37.2)
+       /opt/chef/embedded/bin/ruby -I/tmp/verifier/suites/serverspec -I/tmp/verifier/gems/gems/rspec-support-3.5.0/lib:/tmp/verifier/gems/gems/rspec-core-3.5.4/lib /opt/chef/embedded/bin/rspec --pattern /tmp/verifier/suites/serverspec/\*\*/\*_spec.rb --color --format documentation --default-path /tmp/verifier/suites/serverspec
 
        Git Daemon
          is listening on port 9418
          has a running service of git-daemon
 
-       Finished in 0.03267 seconds
+       Finished in 0.11521 seconds (files took 0.27702 seconds to load)
        2 examples, 0 failures
-       Finished verifying <server-ubuntu-1004> (0m1.22s).
------> Kitchen is finished. (1m57.54s)
+
+       Finished verifying <server-ubuntu-1004> (0m11.62s).
+-----> Kitchen is finished. (1m36.42s)
 ~~~
 
 Well that was easy!
@@ -164,7 +196,7 @@ I'm going to spare us all a great deal of pain and say that getting CentOS worki
 
 > **Add a platform name to an `excludes` array in a suite to remove the platform/suite combination from testing.**
 
-Let's exclude the `server-centos-64` instance so that it doesn't accidentally get run. Update `.kitchen.yml` to look like the following:
+Let's exclude the `server-centos-72` instance so that it doesn't accidentally get run. Update `.kitchen.yml` to look like the following:
 
 ~~~yaml
 ---
@@ -177,7 +209,7 @@ provisioner:
 platforms:
   - name: ubuntu-12.04
   - name: ubuntu-10.04
-  - name: centos-6.4
+  - name: centos-7.2
 
 suites:
   - name: default
@@ -189,19 +221,19 @@ suites:
       - recipe[git::server]
     attributes:
     excludes:
-      - centos-6.4
+      - centos-7.2
 ~~~
 
 Now let's run `kitchen list` to ensure the instance is gone:
 
 ~~~
 $ kitchen list
-Instance             Driver   Provisioner  Last Action
-default-ubuntu-1204  Vagrant  ChefSolo     <Not Created>
-default-ubuntu-1004  Vagrant  ChefSolo     <Not Created>
-default-centos-64    Vagrant  ChefSolo     <Not Created>
-server-ubuntu-1204   Vagrant  ChefSolo     Verified
-server-ubuntu-1004   Vagrant  ChefSolo     Verified
+Instance             Driver   Provisioner  Verifier  Transport  Last Action    Last Error
+default-ubuntu-1404  Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
+default-ubuntu-1004  Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
+default-centos-72    Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
+server-ubuntu-1404   Vagrant  ChefSolo     Busser    Ssh        Verified       <None>
+server-ubuntu-1004   Vagrant  ChefSolo     Busser    Ssh        Verified       <None>
 ~~~
 
 After so much success we should commit our working code. We want to leave our `Berksfile.lock` out of version control so first we'll edit `.gitignore` to read:
@@ -216,8 +248,8 @@ Now to commit:
 
 ~~~
 $ git add .gitignore .kitchen.yml metadata.rb Berksfile recipes/server.rb test/integration/server/serverspec/git_daemon_spec.rb
-$ git commit -m "Add git-daemon support for Ubuntu 10.04 & 12.04."
-[master 1bb6ead] Add git-daemon support for Ubuntu 10.04 & 12.04.
+$ git commit -m "Add git-daemon support for Ubuntu 10.04 & 14.04."
+[master 1bb6ead] Add git-daemon support for Ubuntu 10.04 & 14.04.
  6 files changed, 44 insertions(+)
  create mode 100644 Berksfile
  create mode 100644 recipes/server.rb
@@ -228,24 +260,24 @@ Finally let's destroy our running instances:
 
 ~~~
 $ kitchen destroy
------> Starting Kitchen (v1.0.0)
------> Destroying <default-ubuntu-1204>...
-       Finished destroying <default-ubuntu-1204> (0m0.00s).
+-----> Starting Kitchen (v1.14.2)
+-----> Destroying <default-ubuntu-1404>...
+       Finished destroying <default-ubuntu-1404> (0m0.00s).
 -----> Destroying <default-ubuntu-1004>...
        Finished destroying <default-ubuntu-1004> (0m0.00s).
------> Destroying <default-centos-64>...
-       Finished destroying <default-centos-64> (0m0.00s).
------> Destroying <server-ubuntu-1204>...
-       [default] Forcing shutdown of VM...
-       [default] Destroying VM and associated drives...
-       Vagrant instance <server-ubuntu-1204> destroyed.
-       Finished destroying <server-ubuntu-1204> (0m3.05s).
+-----> Destroying <default-centos-72>...
+       Finished destroying <default-centos-72> (0m0.00s).
+-----> Destroying <server-ubuntu-1404>...
+       ==> default: Forcing shutdown of VM...
+       ==> default: Destroying VM and associated drives...
+       Vagrant instance <server-ubuntu-1404> destroyed.
+       Finished destroying <server-ubuntu-1404> (0m4.60s).
 -----> Destroying <server-ubuntu-1004>...
-       [default] Forcing shutdown of VM...
-       [default] Destroying VM and associated drives...
+       ==> default: Forcing shutdown of VM...
+       ==> default: Destroying VM and associated drives...
        Vagrant instance <server-ubuntu-1004> destroyed.
-       Finished destroying <server-ubuntu-1004> (0m3.31s).
------> Kitchen is finished. (0m6.69s)
+       Finished destroying <server-ubuntu-1004> (0m3.96s).
+-----> Kitchen is finished. (0m8.99s)
 ~~~
 
 Okay, let's cut it off here, ship it!

--- a/source/docs/getting-started/creating-cookbook.md
+++ b/source/docs/getting-started/creating-cookbook.md
@@ -55,13 +55,11 @@ Now we'll add Test Kitchen to our project by using the **init** subcommand:
 ~~~
 $ kitchen init --driver=kitchen-vagrant
       create  .kitchen.yml
-      create  test/integration/default
+      create  chefignore
       create  .gitignore
       append  .gitignore
       append  .gitignore
-         run  gem install kitchen-vagrant from "."
-Fetching: kitchen-vagrant-0.12.0.gem (100%)
-Successfully installed kitchen-vagrant-0.12.0
+Successfully installed kitchen-vagrant-0.21.1
 1 gem installed
 ~~~
 
@@ -87,8 +85,8 @@ provisioner:
   name: chef_solo
 
 platforms:
-  - name: ubuntu-12.04
-  - name: centos-6.4
+  - name: ubuntu-14.04
+  - name: centos-7.2
 
 suites:
   - name: default
@@ -115,7 +113,7 @@ provisioner:
   name: chef_solo
 
 platforms:
-  - name: ubuntu-12.04
+  - name: ubuntu-14.04
 
 suites:
   - name: default
@@ -128,50 +126,66 @@ To see the results of our work, let's run the `kitchen list` subcommand:
 
 ~~~
 $ kitchen list
-Instance             Driver   Provisioner  Last Action
-default-ubuntu-1204  Vagrant  ChefSolo     <Not Created>
+Instance             Driver   Provisioner  Verifier  Transport  Last Action    Last Error
+default-ubuntu-1404  Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
 ~~~
 
-So what's this `default-ubuntu-1204` thing and what's an "Instance"? A Test Kitchen **Instance** is a pairwise combination of a **Suite** and a **Platform** as laid out in your `.kitchen.yml` file. Test Kitchen has auto-named your only instance by combining the **Suite** name (`"default"`) and the **Platform** name (`"ubuntu-12.04"`) into a form that is safe for DNS and hostname records, namely `"default-ubuntu-1204"`.
+So what's this `default-ubuntu-1404` thing and what's an "Instance"? A Test Kitchen **Instance** is a pairwise combination of a **Suite** and a **Platform** as laid out in your `.kitchen.yml` file. Test Kitchen has auto-named your only instance by combining the **Suite** name (`"default"`) and the **Platform** name (`"ubuntu-14.04"`) into a form that is safe for DNS and hostname records, namely `"default-ubuntu-1404"`.
 
-Okay, let's spin this **Instance** up to see what happens. Test Kitchen calls this the **Create Action**. We're going to be painfully explicit and ask Test Kitchen to only create the `default-ubuntu-1204` instance:
+Okay, let's spin this **Instance** up to see what happens. Test Kitchen calls this the **Create Action**. We're going to be painfully explicit and ask Test Kitchen to only create the `default-ubuntu-1404` instance:
 
 ~~~
-$ kitchen create default-ubuntu-1204
------> Starting Kitchen (v1.0.0)
------> Creating <default-ubuntu-1204>...
+$ kitchen create default-ubuntu-1404
+-----> Starting Kitchen (v1.14.2)
+-----> Creating <default-ubuntu-1404>...
        Bringing machine 'default' up with 'virtualbox' provider...
-       [default] Importing base box 'opscode-ubuntu-12.04'...
-       [default] Matching MAC address for NAT networking...
-       [default] Setting the name of the VM...
-       [default] Clearing any previously set forwarded ports...
-       [default] Creating shared folders metadata...
-       [default] Clearing any previously set network interfaces...
-       [default] Preparing network interfaces based on configuration...
-       [default] Forwarding ports...
-       [default] -- 22 => 2222 (adapter 1)
-       [default] Running 'pre-boot' VM customizations...
-       [default] Booting VM...
-[default] Waiting for machine to boot. This may take a few minutes...       [default] Machine booted and ready!
-       [default] Setting hostname...
-       [default] Mounting shared folders...
-       Vagrant instance <default-ubuntu-1204> created.
-       Finished creating <default-ubuntu-1204> (0m53.30s).
------> Kitchen is finished. (0m53.59s)
+       ==> default: Importing base box 'bento/ubuntu-14.04'...
+==> default: Matching MAC address for NAT networking...
+       ==> default: Checking if box 'bento/ubuntu-14.04' is up to date...
+       ==> default: Setting the name of the VM: kitchen-git-cookbook-default-ubuntu-1404_default_1482056833777_92056
+       ==> default: Fixed port collision for 22 => 2222. Now on port 2200.
+       ==> default: Clearing any previously set network interfaces...
+       ==> default: Preparing network interfaces based on configuration...
+           default: Adapter 1: nat
+       ==> default: Forwarding ports...
+           default: 22 (guest) => 2200 (host) (adapter 1)
+       ==> default: Running 'pre-boot' VM customizations...
+       ==> default: Booting VM...
+       ==> default: Waiting for machine to boot. This may take a few minutes...
+           default: SSH address: 127.0.0.1:2200
+           default: SSH username: vagrant
+           default: SSH auth method: private key
+           default:
+           default: Vagrant insecure key detected. Vagrant will automatically replace
+           default: this with a newly generated keypair for better security.
+           default:
+           default: Inserting generated public key within guest...
+           default: Removing insecure key from the guest if it's present...
+           default: Key inserted! Disconnecting and reconnecting using new SSH key...
+       ==> default: Machine booted and ready!
+       ==> default: Checking for guest additions in VM...
+       ==> default: Setting hostname...
+       ==> default: Mounting shared folders...
+           default: /tmp/omnibus/cache => /Users/dom/.kitchen/cache
+       ==> default: Machine not provisioned because `--no-provision` is specified.
+       [SSH] Established
+       Vagrant instance <default-ubuntu-1404> created.
+       Finished creating <default-ubuntu-1404> (0m33.04s).
+-----> Kitchen is finished. (0m33.18s)
 ~~~
 
 If you are a Vagrant user then the line containing `vagrant up --no-provision` will look familiar. Let's check the status of our instance now:
 
 ~~~
 $ kitchen list
-Instance             Driver   Provisioner  Last Action
-default-ubuntu-1204  Vagrant  ChefSolo     Created
+Instance             Driver   Provisioner  Verifier  Transport  Last Action  Last Error
+default-ubuntu-1404  Vagrant  ChefSolo     Busser    Ssh        Created      <None>
 ~~~
 
 Let's commit our glorious work:
 
 ~~~
-$ git add .gitignore .kitchen.yml
+$ git add .gitignore .kitchen.yml chefignore
 $ git commit -m "Add Test Kitchen to the project."
 [master 431068c] Add Test Kitchen to the project.
  2 files changed, 17 insertions(+)

--- a/source/docs/getting-started/fixing-converge.md
+++ b/source/docs/getting-started/fixing-converge.md
@@ -21,9 +21,9 @@ provisioner:
   name: chef_solo
 
 platforms:
-  - name: ubuntu-12.04
+  - name: ubuntu-14.04
   - name: ubuntu-10.04
-  - name: centos-6.4
+  - name: centos-7.2
 
 suites:
   - name: default
@@ -36,119 +36,178 @@ And run `kitchen list` to confirm the introduction of our latest instance:
 
 ~~~
 $ kitchen list
-Instance             Driver   Provisioner  Last Action
-default-ubuntu-1204  Vagrant  ChefSolo     <Not Created>
-default-ubuntu-1004  Vagrant  ChefSolo     <Not Created>
-default-centos-64    Vagrant  ChefSolo     <Not Created>
+Instance             Driver   Provisioner  Verifier  Transport  Last Action    Last Error
+default-ubuntu-1404  Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
+default-ubuntu-1004  Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
+default-centos-72    Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
 ~~~
 
 Now we'll run the **test** subcommand and go grab a coffee:
 
 ~~~
 $ kitchen test 10
------> Starting Kitchen (v1.0.0)
+-----> Starting Kitchen (v1.14.2)
 -----> Cleaning up any prior instances of <default-ubuntu-1004>
 -----> Destroying <default-ubuntu-1004>...
        Finished destroying <default-ubuntu-1004> (0m0.00s).
 -----> Testing <default-ubuntu-1004>
 -----> Creating <default-ubuntu-1004>...
        Bringing machine 'default' up with 'virtualbox' provider...
-       [default] Importing base box 'opscode-ubuntu-10.04'...
-       [default] Matching MAC address for NAT networking...
-       [default] Setting the name of the VM...
-       [default] Clearing any previously set forwarded ports...
-       [default] Creating shared folders metadata...
-       [default] Clearing any previously set network interfaces...
-       [default] Preparing network interfaces based on configuration...
-       [default] Forwarding ports...
-       [default] -- 22 => 2222 (adapter 1)
-       [default] Running 'pre-boot' VM customizations...
-       [default] Booting VM...
-[default] Waiting for machine to boot. This may take a few minutes...       [default] Machine booted and ready!
-       [default] Setting hostname...
-       [default] Mounting shared folders...
+       ==> default: Box 'bento/ubuntu-10.04' could not be found. Attempting to find and install...
+           default: Box Provider: virtualbox
+           default: Box Version: >= 0
+       ==> default: Loading metadata for box 'bento/ubuntu-10.04'
+           default: URL: https://atlas.hashicorp.com/bento/ubuntu-10.04
+       ==> default: Adding box 'bento/ubuntu-10.04' (v2.2.3) for provider: virtualbox
+           default: Downloading: https://atlas.hashicorp.com/bento/boxes/ubuntu-10.04/versions/2.2.3/providers/virtualbox.box
+==> default: Successfully added box 'bento/ubuntu-10.04' (v2.2.3) for 'virtualbox'!
+       ==> default: Importing base box 'bento/ubuntu-10.04'...
+==> default: Matching MAC address for NAT networking...
+       ==> default: Checking if box 'bento/ubuntu-10.04' is up to date...
+       ==> default: Setting the name of the VM: kitchen-git-cookbook-default-ubuntu-1004_default_1482064389709_39381
+       ==> default: Clearing any previously set network interfaces...
+       ==> default: Preparing network interfaces based on configuration...
+           default: Adapter 1: nat
+       ==> default: Forwarding ports...
+           default: 22 (guest) => 2222 (host) (adapter 1)
+       ==> default: Running 'pre-boot' VM customizations...
+       ==> default: Booting VM...
+       ==> default: Waiting for machine to boot. This may take a few minutes...
+           default: SSH address: 127.0.0.1:2222
+           default: SSH username: vagrant
+           default: SSH auth method: private key
+           default:
+           default: Vagrant insecure key detected. Vagrant will automatically replace
+           default: this with a newly generated keypair for better security.
+           default:
+           default: Inserting generated public key within guest...
+           default: Removing insecure key from the guest if it's present...
+           default: Key inserted! Disconnecting and reconnecting using new SSH key...
+       ==> default: Machine booted and ready!
+       ==> default: Checking for guest additions in VM...
+           default: The guest additions on this VM do not match the installed version of
+           default: VirtualBox! In most cases this is fine, but in rare cases it can
+           default: prevent things such as shared folders from working properly. If you see
+           default: shared folder errors, please make sure the guest additions within the
+           default: virtual machine match the version of VirtualBox you have installed on
+           default: your host and reload your VM.
+           default:
+           default: Guest Additions Version: 5.0.12
+           default: VirtualBox Version: 5.1
+       ==> default: Setting hostname...
+       ==> default: Mounting shared folders...
+           default: /tmp/omnibus/cache => /Users/dom/.kitchen/cache
+       ==> default: Machine not provisioned because `--no-provision` is specified.
+       [SSH] Established
        Vagrant instance <default-ubuntu-1004> created.
-       Finished creating <default-ubuntu-1004> (0m39.75s).
+       Finished creating <default-ubuntu-1004> (11m52.36s).
 -----> Converging <default-ubuntu-1004>...
        Preparing files for transfer
+       Preparing dna.json
        Preparing current project directory as a cookbook
        Removing non-cookbook files before transfer
------> Installing Chef Omnibus (true)
-       downloading https://www.opscode.com/chef/install.sh
-         to file /tmp/install.sh
+       Preparing solo.rb
+-----> Installing Chef Omnibus (install only if missing)
+       Downloading https://omnitruck.chef.io/install.sh to file /tmp/install.sh
+       Trying wget...
+       Trying python...
+       Download complete.
+       ubuntu 10.04 x86_64
+       Getting information for chef stable  for ubuntu...
+       downloading https://omnitruck.chef.io/stable/chef/metadata?v=&p=ubuntu&pv=10.04&m=x86_64
+         to file /tmp/install.sh.905/metadata.txt
        trying wget...
-       Downloading Chef  for ubuntu...
-       Installing Chef
+       trying perl...
+       trying python...
+       sha1	7d30b300f95f00036919ee8bf3b95ab73429e57e
+       sha256	663d6c42c90bbb9463bc02a7c5d777f7aa6ebd52c071a0c1963bc8c4db76dea2
+       url	https://packages.chef.io/files/stable/chef/12.10.24/ubuntu/10.04/chef_12.10.24-1_amd64.deb
+       version	12.10.24
+       downloaded metadata file looks valid...
+       downloading https://packages.chef.io/files/stable/chef/12.10.24/ubuntu/10.04/chef_12.10.24-1_amd64.deb
+         to file /tmp/omnibus/cache/chef_12.10.24-1_amd64.deb
+       trying wget...
+       trying perl...
+       trying python...
+       Comparing checksum with sha256sum...
+
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+
+       You are installing an omnibus package without a version pin.  If you are installing
+       on production servers via an automated process this is DANGEROUS and you will
+       be upgraded without warning on new releases, even to new major releases.
+       Letting the version float is only appropriate in desktop, test, development or
+       CI/CD environments.
+
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+
+       Installing chef
+       installing with dpkg...
        Selecting previously deselected package chef.
-(Reading database ... 60%...
-(Reading database ... 44103 files and directories currently installed.)
-       Unpacking chef (from .../tmp.ruCJgCrm/chef__amd64.deb) ...
-       Setting up chef (11.8.0-1.ubuntu.10.04) ...
+(Reading database ... 21183 files and directories currently installed.)
+       Unpacking chef (from .../chef_12.10.24-1_amd64.deb) ...
+       Setting up chef (12.10.24-1) ...
        Thank you for installing Chef!
 
-       Transfering files to <default-ubuntu-1004>
-       [2013-11-30T22:22:25+00:00] INFO: Forking chef instance to converge...
-       Starting Chef Client, version 11.8.0
-       [2013-11-30T22:22:25+00:00] INFO: *** Chef 11.8.0 ***
-       [2013-11-30T22:22:25+00:00] INFO: Chef-client pid: 976
-       [2013-11-30T22:22:25+00:00] INFO: Setting the run_list to ["recipe[git::default]"] from JSON
-       [2013-11-30T22:22:25+00:00] INFO: Run List is [recipe[git::default]]
-       [2013-11-30T22:22:25+00:00] INFO: Run List expands to [git::default]
-       [2013-11-30T22:22:25+00:00] INFO: Starting Chef Run for default-ubuntu-1004
-       [2013-11-30T22:22:25+00:00] INFO: Running start handlers
-       [2013-11-30T22:22:25+00:00] INFO: Start handlers complete.
+       Transferring files to <default-ubuntu-1004>
+       Starting Chef Client, version 12.10.24
+       Installing Cookbook Gems:
        Compiling Cookbooks...
        Converging 2 resources
        Recipe: git::default
-         * package[git] action install[2013-11-30T22:22:25+00:00] INFO: Processing package[git] action install (git::default line 1)
+         * apt_package[git] action install
 
-       ================================================================================
-       Error executing action `install` on resource 'package[git]'
-       ================================================================================
+           ================================================================================
+           Error executing action `install` on resource 'apt_package[git]'
+           ================================================================================
+
+           Chef::Exceptions::Package
+           -------------------------
+           git has no candidate in the apt-cache
+
+           Resource Declaration:
+           ---------------------
+           # In /tmp/kitchen/cookbooks/git/recipes/default.rb
+
+             1: package "git"
+             2:
+
+           Compiled Resource:
+           ------------------
+           # Declared in /tmp/kitchen/cookbooks/git/recipes/default.rb:1:in `from_file'
+
+           apt_package("git") do
+             package_name "git"
+             action [:install]
+             retries 0
+             retry_delay 2
+             default_guard_interpreter :default
+             declared_type :package
+             cookbook_name :git
+             recipe_name "default"
+           end
+
+           Platform:
+           ---------
+           x86_64-linux
 
 
-       Chef::Exceptions::Package
-       -------------------------
-       git has no candidate in the apt-cache
-
-
-       Resource Declaration:
-       ---------------------
-       # In /tmp/kitchen/cookbooks/git/recipes/default.rb
-
-         1: package "git"
-         2:
-
-
-
-       Compiled Resource:
-       ------------------
-       # Declared in /tmp/kitchen/cookbooks/git/recipes/default.rb:1:in `from_file'
-
-       package("git") do
-         action :install
-         retries 0
-         retry_delay 2
-         package_name "git"
-         cookbook_name :git
-         recipe_name "default"
-       end
-
-
-
-       [2013-11-30T22:22:26+00:00] INFO: Running queued delayed notifications before re-raising exception
-       [2013-11-30T22:22:26+00:00] ERROR: Running exception handlers
-       [2013-11-30T22:22:26+00:00] ERROR: Exception handlers complete
-       [2013-11-30T22:22:26+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
-       Chef Client failed. 0 resources updated
-       [2013-11-30T22:22:26+00:00] ERROR: package[git] (git::default line 1) had an error: Chef::Exceptions::Package: git has no candidate in the apt-cache
-       [2013-11-30T22:22:26+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
->>>>>> Converge failed on instance <default-ubuntu-1004>.
->>>>>> Please see .kitchen/logs/default-ubuntu-1004.log for more details
+       Running handlers:
+       [2016-12-18T12:35:46+00:00] ERROR: Running exception handlers
+       Running handlers complete
+       [2016-12-18T12:35:46+00:00] ERROR: Exception handlers complete
+       Chef Client failed. 0 resources updated in 02 seconds
+       [2016-12-18T12:35:46+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
+       [2016-12-18T12:35:46+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
+       [2016-12-18T12:35:46+00:00] ERROR: apt_package[git] (git::default line 1) had an error: Chef::Exceptions::Package: git has no candidate in the apt-cache
+       [2016-12-18T12:35:46+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
 >>>>>> ------Exception-------
 >>>>>> Class: Kitchen::ActionFailed
->>>>>> Message: SSH exited (1) for command: [sudo -E chef-solo --config /tmp/kitchen/solo.rb --json-attributes /tmp/kitchen/dna.json  --log_level info]
+>>>>>> Message: 1 actions failed.
+>>>>>>     Converge failed on instance <default-ubuntu-1004>.  Please see .kitchen/logs/default-ubuntu-1004.log for more details
 >>>>>> ----------------------
+>>>>>> Please see .kitchen/logs/kitchen.log for more details
+>>>>>> Also try running `kitchen diagnose --all` for configuration
 ~~~
 
 Oh noes! Argh, why!? Let's login to the instance and see if we can figure out what the correct package is:
@@ -204,239 +263,310 @@ This may not be pretty but let's verify that it works first on Ubuntu 10.04:
 
 ~~~
 $ kitchen verify 10
------> Starting Kitchen (v1.0.0)
+-----> Starting Kitchen (v1.14.2)
+-----> Creating <default-ubuntu-1004>...
+       Bringing machine 'default' up with 'virtualbox' provider...
+       ==> default: Checking if box 'bento/ubuntu-10.04' is up to date...
+       ==> default: Machine not provisioned because `--no-provision` is specified.
+       [SSH] Established
+       Vagrant instance <default-ubuntu-1004> created.
+       Finished creating <default-ubuntu-1004> (0m5.77s).
 -----> Converging <default-ubuntu-1004>...
        Preparing files for transfer
-       Preparing current project directory as a cookbook
+       Preparing dna.json
+       Resolving cookbook dependencies with Berkshelf 5.3.0...
        Removing non-cookbook files before transfer
-       Transfering files to <default-ubuntu-1004>
-       [2013-11-30T22:25:56+00:00] INFO: Forking chef instance to converge...
-       Starting Chef Client, version 11.8.0
-       [2013-11-30T22:25:56+00:00] INFO: *** Chef 11.8.0 ***
-       [2013-11-30T22:25:56+00:00] INFO: Chef-client pid: 1172
-       [2013-11-30T22:25:57+00:00] INFO: Setting the run_list to ["recipe[git::default]"] from JSON
-       [2013-11-30T22:25:57+00:00] INFO: Run List is [recipe[git::default]]
-       [2013-11-30T22:25:57+00:00] INFO: Run List expands to [git::default]
-       [2013-11-30T22:25:57+00:00] INFO: Starting Chef Run for default-ubuntu-1004
-       [2013-11-30T22:25:57+00:00] INFO: Running start handlers
-       [2013-11-30T22:25:57+00:00] INFO: Start handlers complete.
+       Preparing solo.rb
+-----> Chef Omnibus installation detected (install only if missing)
+       Transferring files to <default-ubuntu-1004>
+       Starting Chef Client, version 12.10.24
+       Installing Cookbook Gems:
        Compiling Cookbooks...
+       [2016-12-18T14:39:06+00:00] WARN: Chef::Provider::AptRepository already exists!  Cannot create deprecation class for LWRP provider apt_repository from cookbook apt
+       [2016-12-18T14:39:06+00:00] WARN: AptRepository already exists!  Deprecation class overwrites Custom resource apt_repository from cookbook apt
        Converging 2 resources
        Recipe: git::default
-         * package[git-core] action install[2013-11-30T22:25:57+00:00] INFO: Processing package[git-core] action install (git::default line 2)
-
+         * apt_package[git-core] action install
            - install version 1:1.7.0.4-1ubuntu0.2 of package git-core
-
-         * log[Well, that was too easy] action write[2013-11-30T22:26:14+00:00] INFO: Processing log[Well, that was too easy] action write (git::default line 7)
-       [2013-11-30T22:26:14+00:00] INFO: Well, that was too easy
+         * log[Well, that was too easy] action write
 
 
-       [2013-11-30T22:26:14+00:00] INFO: Chef Run complete in 17.21367679 seconds
-       [2013-11-30T22:26:14+00:00] INFO: Running report handlers
-       [2013-11-30T22:26:14+00:00] INFO: Report handlers complete
-       Chef Client finished, 2 resources updated
-       Finished converging <default-ubuntu-1004> (0m18.48s).
+       Running handlers:
+       Running handlers complete
+       Chef Client finished, 2/2 resources updated in 02 seconds
+       Finished converging <default-ubuntu-1004> (0m3.27s).
 -----> Setting up <default-ubuntu-1004>...
-Fetching: thor-0.18.1.gem (100%)
-Fetching: busser-0.6.0.gem (100%)
-       Successfully installed thor-0.18.1
-       Successfully installed busser-0.6.0
-       2 gems installed
------> Setting up Busser
-       Creating BUSSER_ROOT in /tmp/busser
-       Creating busser binstub
-       Plugin bats installed (version 0.1.0)
------> Running postinstall for bats plugin
-             create  /tmp/bats20131130-1964-lmhebd/bats
-             create  /tmp/bats20131130-1964-lmhebd/bats.tar.gz
-       Installed Bats to /tmp/busser/vendor/bats/bin/bats
-             remove  /tmp/bats20131130-1964-lmhebd
-       Finished setting up <default-ubuntu-1004> (0m4.42s).
+       Finished setting up <default-ubuntu-1004> (0m0.00s).
 -----> Verifying <default-ubuntu-1004>...
-       Suite path directory /tmp/busser/suites does not exist, skipping.
-       Uploading /tmp/busser/suites/bats/git_installed.bats (mode=0644)
+       Preparing files for transfer
+-----> Busser installation detected (busser)
+       Installing Busser plugins: busser-bats
+       Plugin bats already installed
+       Removing /tmp/verifier/suites/bats
+       Transferring files to <default-ubuntu-1004>
 -----> Running bats test suite
  ✓ git binary is found in PATH
 
        1 test, 0 failures
-       Finished verifying <default-ubuntu-1004> (0m0.89s).
------> Kitchen is finished. (0m24.20s)
+       Finished verifying <default-ubuntu-1004> (0m3.26s).
+-----> Kitchen is finished. (0m12.74s)
 ~~~
 
 Back to green, good. Let's verify that the other two instances are still good. We'll use a Ruby regular expression to glob the two other instances into one Test Kitchen command:
 
 ~~~
-$ kitchen verify '(12|64)'
------> Starting Kitchen (v1.0.0)
------> Creating <default-ubuntu-1204>...
+$ kitchen verify '(14|72)'
+-----> Starting Kitchen (v1.14.2)
+-----> Creating <default-ubuntu-1404>...
        Bringing machine 'default' up with 'virtualbox' provider...
-       [default] Importing base box 'opscode-ubuntu-12.04'...
-       [default] Matching MAC address for NAT networking...
-       [default] Setting the name of the VM...
-       [default] Clearing any previously set forwarded ports...
-       [default] Fixed port collision for 22 => 2222. Now on port 2200.
-       [default] Creating shared folders metadata...
-       [default] Clearing any previously set network interfaces...
-       [default] Preparing network interfaces based on configuration...
-       [default] Forwarding ports...
-       [default] -- 22 => 2200 (adapter 1)
-       [default] Running 'pre-boot' VM customizations...
-       [default] Booting VM...
-       [default] Waiting for machine to boot. This may take a few minutes...
-       [default] Machine booted and ready!
-       [default] Setting hostname...
-       [default] Mounting shared folders...
-       Vagrant instance <default-ubuntu-1204> created.
-       Finished creating <default-ubuntu-1204> (0m48.28s).
------> Converging <default-ubuntu-1204>...
+       ==> default: Importing base box 'bento/ubuntu-14.04'...
+==> default: Matching MAC address for NAT networking...
+       ==> default: Checking if box 'bento/ubuntu-14.04' is up to date...
+       ==> default: Setting the name of the VM: kitchen-git-cookbook-default-ubuntu-1404_default_1482072025256_65340
+       ==> default: Fixed port collision for 22 => 2222. Now on port 2200.
+       ==> default: Clearing any previously set network interfaces...
+       ==> default: Preparing network interfaces based on configuration...
+           default: Adapter 1: nat
+       ==> default: Forwarding ports...
+           default: 22 (guest) => 2200 (host) (adapter 1)
+       ==> default: Running 'pre-boot' VM customizations...
+       ==> default: Booting VM...
+       ==> default: Waiting for machine to boot. This may take a few minutes...
+           default: SSH address: 127.0.0.1:2200
+           default: SSH username: vagrant
+           default: SSH auth method: private key
+           default:
+           default: Vagrant insecure key detected. Vagrant will automatically replace
+           default: this with a newly generated keypair for better security.
+           default:
+           default: Inserting generated public key within guest...
+           default: Removing insecure key from the guest if it's present...
+           default: Key inserted! Disconnecting and reconnecting using new SSH key...
+       ==> default: Machine booted and ready!
+       ==> default: Checking for guest additions in VM...
+       ==> default: Setting hostname...
+       ==> default: Mounting shared folders...
+           default: /tmp/omnibus/cache => /Users/dom/.kitchen/cache
+       ==> default: Machine not provisioned because `--no-provision` is specified.
+       [SSH] Established
+       Vagrant instance <default-ubuntu-1404> created.
+       Finished creating <default-ubuntu-1404> (0m33.22s).
+-----> Converging <default-ubuntu-1404>...
        Preparing files for transfer
-       Preparing current project directory as a cookbook
+       Preparing dna.json
+       Resolving cookbook dependencies with Berkshelf 5.3.0...
        Removing non-cookbook files before transfer
------> Installing Chef Omnibus (true)
-       downloading https://www.opscode.com/chef/install.sh
-         to file /tmp/install.sh
+       Preparing solo.rb
+-----> Installing Chef Omnibus (install only if missing)
+       Downloading https://omnitruck.chef.io/install.sh to file /tmp/install.sh
+       Trying wget...
+       Download complete.
+       ubuntu 14.04 x86_64
+       Getting information for chef stable  for ubuntu...
+       downloading https://omnitruck.chef.io/stable/chef/metadata?v=&p=ubuntu&pv=14.04&m=x86_64
+         to file /tmp/install.sh.1482/metadata.txt
        trying wget...
-Downloading Chef  for ubuntu...
-Installing Chef
-Selecting previously unselected package chef.
-(Reading database ... 53291 files and directories currently installed.)
-Unpacking chef (from .../tmp.K5ozaWkv/chef__amd64.deb) ...
-Setting up chef (11.8.0-1.ubuntu.12.04) ...
-Thank you for installing Chef!
-       Transfering files to <default-ubuntu-1204>
-[2013-11-30T22:28:54+00:00] INFO: Forking chef instance to converge...
-Starting Chef Client, version 11.8.0
-[2013-11-30T22:28:55+00:00] INFO: *** Chef 11.8.0 ***
-[2013-11-30T22:28:55+00:00] INFO: Chef-client pid: 1172
-[2013-11-30T22:28:55+00:00] INFO: Setting the run_list to ["recipe[git::default]"] from JSON
-[2013-11-30T22:28:55+00:00] INFO: Run List is [recipe[git::default]]
-[2013-11-30T22:28:55+00:00] INFO: Run List expands to [git::default]
-[2013-11-30T22:28:55+00:00] INFO: Starting Chef Run for default-ubuntu-1204
-[2013-11-30T22:28:55+00:00] INFO: Running start handlers
-[2013-11-30T22:28:55+00:00] INFO: Start handlers complete.
-Compiling Cookbooks...
-Converging 2 resources
-Recipe: git::default
-  * package[git] action install[2013-11-30T22:28:55+00:00] INFO: Processing package[git] action install (git::default line 4)
+       sha1	10b9026d57005aaf31289aec650931a02b5347d3
+       sha256	de5991b073fb22aa295fd0142f5e4ed3ca7da6ffe2c3fdcb01da29e4cdd0bd04
+       url	https://packages.chef.io/files/stable/chef/12.17.44/ubuntu/14.04/chef_12.17.44-1_amd64.deb
+       version	12.17.44
+       downloaded metadata file looks valid...
+       /tmp/omnibus/cache/chef_12.17.44-1_amd64.deb already exists, verifiying checksum...
+       Comparing checksum with sha256sum...
+       checksum compare succeeded, using existing file!
 
-    - install version 1:1.7.9.5-1 of package git
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
 
-  * log[Well, that was too easy] action write[2013-11-30T22:29:16+00:00] INFO: Processing log[Well, that was too easy] action write (git::default line 7)
-[2013-11-30T22:29:16+00:00] INFO: Well, that was too easy
+       You are installing an omnibus package without a version pin.  If you are installing
+       on production servers via an automated process this is DANGEROUS and you will
+       be upgraded without warning on new releases, even to new major releases.
+       Letting the version float is only appropriate in desktop, test, development or
+       CI/CD environments.
 
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
 
-[2013-11-30T22:29:16+00:00] INFO: Chef Run complete in 21.557709331 seconds
-[2013-11-30T22:29:16+00:00] INFO: Running report handlers
-[2013-11-30T22:29:16+00:00] INFO: Report handlers complete
-Chef Client finished, 2 resources updated
-       Finished converging <default-ubuntu-1204> (0m55.32s).
------> Setting up <default-ubuntu-1204>...
-Fetching: thor-0.18.1.gem (100%)
-Fetching: busser-0.6.0.gem (100%)
-Successfully installed thor-0.18.1
-Successfully installed busser-0.6.0
-2 gems installed
------> Setting up Busser
-       Creating BUSSER_ROOT in /tmp/busser
-       Creating busser binstub
-       Plugin bats installed (version 0.1.0)
------> Running postinstall for bats plugin
-      create  /tmp/bats20131130-4144-d2coam/bats
-      create  /tmp/bats20131130-4144-d2coam/bats.tar.gz
-Installed Bats to /tmp/busser/vendor/bats/bin/bats
-      remove  /tmp/bats20131130-4144-d2coam
-       Finished setting up <default-ubuntu-1204> (0m4.96s).
------> Verifying <default-ubuntu-1204>...
-       Suite path directory /tmp/busser/suites does not exist, skipping.
-Uploading /tmp/busser/suites/bats/git_installed.bats (mode=0644)
------> Running bats test suite
- ✓ git binary is found in PATH
-
-1 test, 0 failures
-       Finished verifying <default-ubuntu-1204> (0m0.86s).
------> Creating <default-centos-64>...
-       Bringing machine 'default' up with 'virtualbox' provider...
-       [default] Importing base box 'opscode-centos-6.4'...
-       [default] Matching MAC address for NAT networking...
-       [default] Setting the name of the VM...
-       [default] Clearing any previously set forwarded ports...
-       [default] Fixed port collision for 22 => 2222. Now on port 2201.
-       [default] Creating shared folders metadata...
-       [default] Clearing any previously set network interfaces...
-       [default] Preparing network interfaces based on configuration...
-       [default] Forwarding ports...
-       [default] -- 22 => 2201 (adapter 1)
-       [default] Running 'pre-boot' VM customizations...
-       [default] Booting VM...
-[default] Waiting for machine to boot. This may take a few minutes...       [default] Machine booted and ready!
-       [default] Setting hostname...
-       [default] Mounting shared folders...
-       Vagrant instance <default-centos-64> created.
-       Finished creating <default-centos-64> (0m54.26s).
------> Converging <default-centos-64>...
-       Preparing files for transfer
-       Preparing current project directory as a cookbook
-       Removing non-cookbook files before transfer
------> Installing Chef Omnibus (true)
-       downloading https://www.opscode.com/chef/install.sh
-         to file /tmp/install.sh
-       trying wget...
-       Downloading Chef  for el...
-       Installing Chef
-       warning: /tmp/tmp.YE63OB3z/chef-.x86_64.rpm: Header V4 DSA/SHA1 Signature, key ID 83ef826a: NOKEY
-Preparing...                #####  ########################################### [100%]
-   1:chef                          ########################################### [100%]
+       Installing chef
+       installing with dpkg...
+       Selecting previously unselected package chef.
+(Reading database ... 35284 files and directories currently installed.)
+       Preparing to unpack .../chef_12.17.44-1_amd64.deb ...
+       Unpacking chef (12.17.44-1) ...
+       Setting up chef (12.17.44-1) ...
        Thank you for installing Chef!
-       Transfering files to <default-centos-64>
-       [2013-11-30T22:31:01+00:00] INFO: Forking chef instance to converge...
-       Starting Chef Client, version 11.8.0
-       [2013-11-30T22:31:01+00:00] INFO: *** Chef 11.8.0 ***
-       [2013-11-30T22:31:01+00:00] INFO: Chef-client pid: 2471
-       [2013-11-30T22:31:02+00:00] INFO: Setting the run_list to ["recipe[git::default]"] from JSON
-       [2013-11-30T22:31:02+00:00] INFO: Run List is [recipe[git::default]]
-       [2013-11-30T22:31:02+00:00] INFO: Run List expands to [git::default]
-       [2013-11-30T22:31:02+00:00] INFO: Starting Chef Run for default-centos-64
-       [2013-11-30T22:31:02+00:00] INFO: Running start handlers
-       [2013-11-30T22:31:02+00:00] INFO: Start handlers complete.
+       Transferring files to <default-ubuntu-1404>
+       Starting Chef Client, version 12.17.44
+       Creating a new client identity for default-ubuntu-1404 using the validator key.
+       resolving cookbooks for run list: ["git::default"]
+       Synchronizing Cookbooks:
+         - git (0.1.0)
+         - ubuntu (2.0.0)
+         - apt (5.0.0)
+         - compat_resource (12.16.2)
+       Installing Cookbook Gems:
        Compiling Cookbooks...
-Converging 2 resources
+       [2016-12-18T14:40:56+00:00] WARN: Chef::Provider::AptRepository already exists!  Cannot create deprecation class for LWRP provider apt_repository from cookbook apt
+       [2016-12-18T14:40:56+00:00] WARN: AptRepository already exists!  Deprecation class overwrites Custom resource apt_repository from cookbook apt
+       Converging 2 resources
        Recipe: git::default
-         * package[git] action install[2013-11-30T22:31:02+00:00] INFO: Processing package[git] action install (git::default line 4)
-        (up to date)
-         * log[Well, that was too easy] action write[2013-11-30T22:31:55+00:00] INFO: Processing log[Well, that was too easy] action write (git::default line 7)
-       [2013-11-30T22:31:55+00:00] INFO: Well, that was too easy
+         * apt_package[git] action install
+           - install version 1:1.9.1-1ubuntu0.3 of package git
+         * log[Well, that was too easy] action write
 
 
-       [2013-11-30T22:31:55+00:00] INFO: Chef Run complete in 52.919344438 seconds
-       [2013-11-30T22:31:55+00:00] INFO: Running report handlers
-       [2013-11-30T22:31:55+00:00] INFO: Report handlers complete
-       Chef Client finished, 1 resources updated
-       Finished converging <default-centos-64> (1m39.61s).
------> Setting up <default-centos-64>...
-Fetching: thor-0.18.1.gem (100%)
-Fetching: busser-0.6.0.gem (100%)
-       Successfully installed thor-0.18.1
-       Successfully installed busser-0.6.0
+       Running handlers:
+       Running handlers complete
+       Chef Client finished, 2/2 resources updated in 14 seconds
+       Finished converging <default-ubuntu-1404> (0m23.04s).
+-----> Setting up <default-ubuntu-1404>...
+       Finished setting up <default-ubuntu-1404> (0m0.00s).
+-----> Verifying <default-ubuntu-1404>...
+       Preparing files for transfer
+-----> Installing Busser (busser)
+Fetching: thor-0.19.0.gem (100%)
+       Successfully installed thor-0.19.0
+Fetching: busser-0.7.1.gem (100%)
+       Successfully installed busser-0.7.1
        2 gems installed
------> Setting up Busser
-       Creating BUSSER_ROOT in /tmp/busser
-       Creating busser binstub
-       Plugin bats installed (version 0.1.0)
+       Installing Busser plugins: busser-bats
+       Plugin bats installed (version 0.3.0)
 -----> Running postinstall for bats plugin
-             create  /tmp/bats20131130-2633-10aemp/bats
-             create  /tmp/bats20131130-2633-10aemp/bats.tar.gz
-       Installed Bats to /tmp/busser/vendor/bats/bin/bats
-             remove  /tmp/bats20131130-2633-10aemp
-       Finished setting up <default-centos-64> (0m43.89s).
------> Verifying <default-centos-64>...
-       Suite path directory /tmp/busser/suites does not exist, skipping.
-       Uploading /tmp/busser/suites/bats/git_installed.bats (mode=0644)
+       Installed Bats to /tmp/verifier/vendor/bats/bin/bats
+       Suite path directory /tmp/verifier/suites does not exist, skipping.
+       Transferring files to <default-ubuntu-1404>
 -----> Running bats test suite
  ✓ git binary is found in PATH
 
        1 test, 0 failures
-       Finished verifying <default-centos-64> (0m0.90s).
------> Kitchen is finished. (5m8.42s)
+       Finished verifying <default-ubuntu-1404> (0m5.32s).
+-----> Creating <default-centos-72>...
+       Bringing machine 'default' up with 'virtualbox' provider...
+       ==> default: Importing base box 'bento/centos-7.2'...
+==> default: Matching MAC address for NAT networking...
+       ==> default: Checking if box 'bento/centos-7.2' is up to date...
+       ==> default: Setting the name of the VM: kitchen-git-cookbook-default-centos-72_default_1482072084722_73400
+       ==> default: Fixed port collision for 22 => 2222. Now on port 2201.
+       ==> default: Clearing any previously set network interfaces...
+       ==> default: Preparing network interfaces based on configuration...
+           default: Adapter 1: nat
+       ==> default: Forwarding ports...
+           default: 22 (guest) => 2201 (host) (adapter 1)
+       ==> default: Running 'pre-boot' VM customizations...
+       ==> default: Booting VM...
+       ==> default: Waiting for machine to boot. This may take a few minutes...
+           default: SSH address: 127.0.0.1:2201
+           default: SSH username: vagrant
+           default: SSH auth method: private key
+           default: Warning: Remote connection disconnect. Retrying...
+           default:
+           default: Vagrant insecure key detected. Vagrant will automatically replace
+           default: this with a newly generated keypair for better security.
+           default:
+           default: Inserting generated public key within guest...
+           default: Removing insecure key from the guest if it's present...
+           default: Key inserted! Disconnecting and reconnecting using new SSH key...
+       ==> default: Machine booted and ready!
+       ==> default: Checking for guest additions in VM...
+       ==> default: Setting hostname...
+       ==> default: Mounting shared folders...
+           default: /tmp/omnibus/cache => /Users/dom/.kitchen/cache
+       ==> default: Machine not provisioned because `--no-provision` is specified.
+       /etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
+       [SSH] Established
+       Vagrant instance <default-centos-72> created.
+       Finished creating <default-centos-72> (0m51.74s).
+-----> Converging <default-centos-72>...
+       Preparing files for transfer
+       Preparing dna.json
+       Resolving cookbook dependencies with Berkshelf 5.3.0...
+       Removing non-cookbook files before transfer
+       Preparing solo.rb
+       /etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
+-----> Installing Chef Omnibus (install only if missing)
+       Downloading https://omnitruck.chef.io/install.sh to file /tmp/install.sh
+       Trying wget...
+       Download complete.
+       el 7 x86_64
+       Getting information for chef stable  for el...
+       downloading https://omnitruck.chef.io/stable/chef/metadata?v=&p=el&pv=7&m=x86_64
+         to file /tmp/install.sh.11078/metadata.txt
+       trying wget...
+       sha1	ffa2c60116d57c8b987ee2e906bff9106c98daf5
+       sha256	beccc11f5861bde369f62ca3fd7361b536786e91d73f538857e625a622f8caef
+       url	https://packages.chef.io/files/stable/chef/12.17.44/el/7/chef-12.17.44-1.el7.x86_64.rpm
+       version	12.17.44
+       downloaded metadata file looks valid...
+       /tmp/omnibus/cache/chef-12.17.44-1.el7.x86_64.rpm already exists, verifiying checksum...
+       Comparing checksum with sha256sum...
+       checksum compare succeeded, using existing file!
+
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+
+       You are installing an omnibus package without a version pin.  If you are installing
+       on production servers via an automated process this is DANGEROUS and you will
+       be upgraded without warning on new releases, even to new major releases.
+       Letting the version float is only appropriate in desktop, test, development or
+       CI/CD environments.
+
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+
+       Installing chef
+       installing with rpm...
+       warning: /tmp/omnibus/cache/chef-12.17.44-1.el7.x86_64.rpm: Header V4 DSA/SHA1 Signature, key ID 83ef826a: NOKEY
+       Preparing...                          ################################# [100%]
+       Updating / installing...
+          1:chef-12.17.44-1.el7              ################################# [100%]
+       Thank you for installing Chef!
+       /etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
+       Transferring files to <default-centos-72>
+       /etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
+       Starting Chef Client, version 12.17.44
+       Creating a new client identity for default-centos-72 using the validator key.
+       resolving cookbooks for run list: ["git::default"]
+       Synchronizing Cookbooks:
+         - git (0.1.0)
+         - ubuntu (2.0.0)
+         - compat_resource (12.16.2)
+         - apt (5.0.0)
+       Installing Cookbook Gems:
+       Compiling Cookbooks...
+       [2016-12-18T14:42:14+00:00] WARN: Chef::Provider::AptRepository already exists!  Cannot create deprecation class for LWRP provider apt_repository from cookbook apt
+       [2016-12-18T14:42:14+00:00] WARN: AptRepository already exists!  Deprecation class overwrites Custom resource apt_repository from cookbook apt
+       Converging 2 resources
+       Recipe: git::default
+         * yum_package[git] action install
+           - install version 1.8.3.1-6.el7_2.1 of package git
+         * log[Well, that was too easy] action write
+
+
+       Running handlers:
+       Running handlers complete
+       Chef Client finished, 2/2 resources updated in 36 seconds
+       Finished converging <default-centos-72> (0m44.16s).
+-----> Setting up <default-centos-72>...
+       Finished setting up <default-centos-72> (0m0.00s).
+-----> Verifying <default-centos-72>...
+       Preparing files for transfer
+       /etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
+-----> Installing Busser (busser)
+Fetching: thor-0.19.0.gem (100%)
+       Successfully installed thor-0.19.0
+Fetching: busser-0.7.1.gem (100%)
+       Successfully installed busser-0.7.1
+       2 gems installed
+       Installing Busser plugins: busser-bats
+       Plugin bats installed (version 0.3.0)
+-----> Running postinstall for bats plugin
+       Installed Bats to /tmp/verifier/vendor/bats/bin/bats
+       /etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
+       Suite path directory /tmp/verifier/suites does not exist, skipping.
+       Transferring files to <default-centos-72>
+       /etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
+-----> Running bats test suite
+ ✓ git binary is found in PATH
+
+       1 test, 0 failures
+       Finished verifying <default-centos-72> (0m4.85s).
+-----> Kitchen is finished. (2m42.79s)
 $ echo $?
 0
 ~~~
@@ -445,23 +575,23 @@ We've successfully verified all three instances, so let's shut them down.
 
 ~~~
 $ kitchen destroy
------> Starting Kitchen (v1.0.0)
------> Destroying <default-ubuntu-1204>...
-       [default] Forcing shutdown of VM...
-       [default] Destroying VM and associated drives...
-       Vagrant instance <default-ubuntu-1204> destroyed.
-       Finished destroying <default-ubuntu-1204> (0m3.37s).
+-----> Starting Kitchen (v1.14.2)
+-----> Destroying <default-ubuntu-1404>...
+       ==> default: Forcing shutdown of VM...
+       ==> default: Destroying VM and associated drives...
+       Vagrant instance <default-ubuntu-1404> destroyed.
+       Finished destroying <default-ubuntu-1404> (0m4.92s).
 -----> Destroying <default-ubuntu-1004>...
-       [default] Forcing shutdown of VM...
-       [default] Destroying VM and associated drives...
+       ==> default: Forcing shutdown of VM...
+       ==> default: Destroying VM and associated drives...
        Vagrant instance <default-ubuntu-1004> destroyed.
-       Finished destroying <default-ubuntu-1004> (0m2.94s).
------> Destroying <default-centos-64>...
-       [default] Forcing shutdown of VM...
-       [default] Destroying VM and associated drives...
-       Vagrant instance <default-centos-64> destroyed.
-       Finished destroying <default-centos-64> (0m2.97s).
------> Kitchen is finished. (0m9.60s)
+       Finished destroying <default-ubuntu-1004> (0m4.01s).
+-----> Destroying <default-centos-72>...
+       ==> default: Forcing shutdown of VM...
+       ==> default: Destroying VM and associated drives...
+       Vagrant instance <default-centos-72> destroyed.
+       Finished destroying <default-centos-72> (0m4.17s).
+-----> Kitchen is finished. (0m13.57s)
 ~~~
 
 And finally commit our code updates:

--- a/source/docs/getting-started/installing.md
+++ b/source/docs/getting-started/installing.md
@@ -49,5 +49,5 @@ Now let's verify that Test Kitchen is installed. To save on typing, the tool's m
 
 ~~~
 $ kitchen version
-Test Kitchen version 1.0.0
+Test Kitchen version 1.14.2
 ~~~

--- a/source/docs/getting-started/manually-verifying.md
+++ b/source/docs/getting-started/manually-verifying.md
@@ -17,12 +17,15 @@ Let's verify this right now.
 Test Kitchen has a **login** subcommand for just these kinds of situations:
 
 ~~~
-$ kitchen login default-ubuntu-1204
-Welcome to Ubuntu 12.04.2 LTS (GNU/Linux 3.5.0-23-generic x86_64)
+$ kitchen login default-ubuntu-1404
+Welcome to Ubuntu 14.04.5 LTS (GNU/Linux 3.13.0-103-generic x86_64)
 
  * Documentation:  https://help.ubuntu.com/
-Last login: Sat Nov 30 21:56:59 2013 from 10.0.2.2
-vagrant@default-ubuntu-1204:~$
+
+...
+
+Last login: Sun Dec 18 10:47:20 2016 from 10.0.2.2
+vagrant@default-ubuntu-1404:~$
 ~~~
 
 As you can see by the prompt above we are now in the `default-ubuntu-1204` instance. We'll denote the prompt in an instance with `# ` for clarity. Now to check if Git is installed:
@@ -31,7 +34,7 @@ As you can see by the prompt above we are now in the `default-ubuntu-1204` insta
 # which git
 /usr/bin/git
 # git --version
-git version 1.7.9.5
+git version 1.9.1
 ~~~
 
 Rockin. Now we can exit out back to our workstation:

--- a/source/docs/getting-started/running-converge.md
+++ b/source/docs/getting-started/running-converge.md
@@ -11,51 +11,70 @@ next:
 Now that we have some code, let's let Test Kitchen run it for us on our Ubuntu 12.04 instance:
 
 ~~~
-$ kitchen converge default-ubuntu-1204
------> Starting Kitchen (v1.0.0)
------> Converging <default-ubuntu-1204>...
+$ kitchen converge default-ubuntu-1404
+-----> Starting Kitchen (v1.14.2)
+-----> Converging <default-ubuntu-1404>...
        Preparing files for transfer
+       Preparing dna.json
        Preparing current project directory as a cookbook
        Removing non-cookbook files before transfer
------> Installing Chef Omnibus (true)
-       downloading https://www.opscode.com/chef/install.sh
-         to file /tmp/install.sh
+       Preparing solo.rb
+-----> Installing Chef Omnibus (install only if missing)
+       Downloading https://omnitruck.chef.io/install.sh to file /tmp/install.sh
+       Trying wget...
+       Download complete.
+       ubuntu 14.04 x86_64
+       Getting information for chef stable  for ubuntu...
+       downloading https://omnitruck.chef.io/stable/chef/metadata?v=&p=ubuntu&pv=14.04&m=x86_64
+         to file /tmp/install.sh.1569/metadata.txt
        trying wget...
-Downloading Chef  for ubuntu...
-Installing Chef
-Selecting previously unselected package chef.
-(Reading database ... 53291 files and directories currently installed.)
-Unpacking chef (from .../tmp.GUasmrcD/chef__amd64.deb) ...
-Setting up chef (11.8.0-1.ubuntu.12.04) ...
-Thank you for installing Chef!
-       Transfering files to <default-ubuntu-1204>
-[2013-11-30T21:55:45+00:00] INFO: Forking chef instance to converge...
-Starting Chef Client, version 11.8.0
-[2013-11-30T21:55:45+00:00] INFO: *** Chef 11.8.0 ***
-[2013-11-30T21:55:45+00:00] INFO: Chef-client pid: 1162
-[2013-11-30T21:55:46+00:00] INFO: Setting the run_list to ["recipe[git::default]"] from JSON
-[2013-11-30T21:55:46+00:00] INFO: Run List is [recipe[git::default]]
-[2013-11-30T21:55:46+00:00] INFO: Run List expands to [git::default]
-[2013-11-30T21:55:46+00:00] INFO: Starting Chef Run for default-ubuntu-1204
-[2013-11-30T21:55:46+00:00] INFO: Running start handlers
-[2013-11-30T21:55:46+00:00] INFO: Start handlers complete.
-Compiling Cookbooks...
-Converging 2 resources
-Recipe: git::default
-  * package[git] action install[2013-11-30T21:55:46+00:00] INFO: Processing package[git] action install (git::default line 1)
+       sha1	10b9026d57005aaf31289aec650931a02b5347d3
+       sha256	de5991b073fb22aa295fd0142f5e4ed3ca7da6ffe2c3fdcb01da29e4cdd0bd04
+       url	https://packages.chef.io/files/stable/chef/12.17.44/ubuntu/14.04/chef_12.17.44-1_amd64.deb
+       version	12.17.44
+       downloaded metadata file looks valid...
+       /tmp/omnibus/cache/chef_12.17.44-1_amd64.deb already exists, verifiying checksum...
+       Comparing checksum with sha256sum...
+       checksum compare succeeded, using existing file!
 
-    - install version 1:1.7.9.5-1 of package git
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
 
-  * log[Well, that was too easy] action write[2013-11-30T21:56:14+00:00] INFO: Processing log[Well, that was too easy] action write (git::default line 3)
-[2013-11-30T21:56:14+00:00] INFO: Well, that was too easy
+       You are installing an omnibus package without a version pin.  If you are installing
+       on production servers via an automated process this is DANGEROUS and you will
+       be upgraded without warning on new releases, even to new major releases.
+       Letting the version float is only appropriate in desktop, test, development or
+       CI/CD environments.
+
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+
+       Installing chef
+       installing with dpkg...
+       Selecting previously unselected package chef.
+(Reading database ... 35284 files and directories currently installed.)
+       Preparing to unpack .../chef_12.17.44-1_amd64.deb ...
+       Unpacking chef (12.17.44-1) ...
+       Setting up chef (12.17.44-1) ...
+       Thank you for installing Chef!
+       Transferring files to <default-ubuntu-1404>
+       Starting Chef Client, version 12.17.44
+       Creating a new client identity for default-ubuntu-1404 using the validator key.
+       resolving cookbooks for run list: ["git::default"]
+       Synchronizing Cookbooks:
+         - git (0.1.0)
+       Installing Cookbook Gems:
+       Compiling Cookbooks...
+       Converging 2 resources
+       Recipe: git::default
+         * apt_package[git] action install
+           - install version 1:1.9.1-1ubuntu0.3 of package git
+         * log[Well, that was too easy] action write
 
 
-[2013-11-30T21:56:14+00:00] INFO: Chef Run complete in 28.139177847 seconds
-[2013-11-30T21:56:14+00:00] INFO: Running report handlers
-[2013-11-30T21:56:14+00:00] INFO: Report handlers complete
-Chef Client finished, 2 resources updated
-       Finished converging <default-ubuntu-1204> (1m3.91s).
------> Kitchen is finished. (1m4.22s)
+       Running handlers:
+       Running handlers complete
+       Chef Client finished, 2/2 resources updated in 21 seconds
+       Finished converging <default-ubuntu-1404> (0m28.08s).
+-----> Kitchen is finished. (0m28.22s)
 ~~~
 
 To quote our Chef run, that **was** too easy. If you are a Chef user then part of the output above should look familiar to you. Here's what happened at a high level:
@@ -67,38 +86,33 @@ To quote our Chef run, that **was** too easy. If you are a Chef user then part o
 There's nothing to stop you from running this command again (or over-and-over for that matter) so, let's see what happens:
 
 ~~~
-$ kitchen converge default-ubuntu-1204
------> Starting Kitchen (v1.0.0)
------> Converging <default-ubuntu-1204>...
+$ kitchen converge default-ubuntu-1404
+-----> Starting Kitchen (v1.14.2)
+-----> Converging <default-ubuntu-1404>...
        Preparing files for transfer
+       Preparing dna.json
        Preparing current project directory as a cookbook
        Removing non-cookbook files before transfer
-       Transfering files to <default-ubuntu-1204>
-[2013-11-30T21:57:00+00:00] INFO: Forking chef instance to converge...
-Starting Chef Client, version 11.8.0
-[2013-11-30T21:57:00+00:00] INFO: *** Chef 11.8.0 ***
-[2013-11-30T21:57:00+00:00] INFO: Chef-client pid: 4142
-[2013-11-30T21:57:01+00:00] INFO: Setting the run_list to ["recipe[git::default]"] from JSON
-[2013-11-30T21:57:01+00:00] INFO: Run List is [recipe[git::default]]
-[2013-11-30T21:57:01+00:00] INFO: Run List expands to [git::default]
-[2013-11-30T21:57:01+00:00] INFO: Starting Chef Run for default-ubuntu-1204
-[2013-11-30T21:57:01+00:00] INFO: Running start handlers
-[2013-11-30T21:57:01+00:00] INFO: Start handlers complete.
-Compiling Cookbooks...
-Converging 2 resources
-Recipe: git::default
-  * package[git] action install[2013-11-30T21:57:01+00:00] INFO: Processing package[git] action install (git::default line 1)
- (up to date)
-  * log[Well, that was too easy] action write[2013-11-30T21:57:01+00:00] INFO: Processing log[Well, that was too easy] action write (git::default line 3)
-[2013-11-30T21:57:01+00:00] INFO: Well, that was too easy
+       Preparing solo.rb
+-----> Chef Omnibus installation detected (install only if missing)
+       Transferring files to <default-ubuntu-1404>
+       Starting Chef Client, version 12.17.44
+       resolving cookbooks for run list: ["git::default"]
+       Synchronizing Cookbooks:
+         - git (0.1.0)
+       Installing Cookbook Gems:
+       Compiling Cookbooks...
+       Converging 2 resources
+       Recipe: git::default
+         * apt_package[git] action install (up to date)
+         * log[Well, that was too easy] action write
 
 
-[2013-11-30T21:57:01+00:00] INFO: Chef Run complete in 0.069998015 seconds
-[2013-11-30T21:57:01+00:00] INFO: Running report handlers
-[2013-11-30T21:57:01+00:00] INFO: Report handlers complete
-Chef Client finished, 1 resources updated
-       Finished converging <default-ubuntu-1204> (0m1.67s).
------> Kitchen is finished. (0m1.99s)
+       Running handlers:
+       Running handlers complete
+       Chef Client finished, 1/2 resources updated in 01 seconds
+       Finished converging <default-ubuntu-1404> (0m2.73s).
+-----> Kitchen is finished. (0m2.86s)
 ~~~
 
 That ran a **lot** faster didn't it? Here's what happened this time:
@@ -118,8 +132,8 @@ Let's check the status of our instance:
 
 ~~~
 $ kitchen list
-Instance             Driver   Provisioner  Last Action
-default-ubuntu-1204  Vagrant  ChefSolo     Converged
+Instance             Driver   Provisioner  Verifier  Transport  Last Action  Last Error
+default-ubuntu-1404  Vagrant  ChefSolo     Busser    Ssh        Converged    <None>
 ~~~
 
 A clean converge run, success! Let's commit our production code and move on:

--- a/source/docs/getting-started/running-test.md
+++ b/source/docs/getting-started/running-test.md
@@ -11,117 +11,147 @@ next:
 Now it's time to introduce to the **test** meta-action which helps you automate all the previous actions so far into one command. Recall that we currently have our instance in a "verified" state. With this in mind, let's run `kitchen test`:
 
 ~~~
-$ kitchen test default-ubuntu-1204
------> Starting Kitchen (v1.0.0)
------> Cleaning up any prior instances of <default-ubuntu-1204>
------> Destroying <default-ubuntu-1204>...
-       [default] Forcing shutdown of VM...
-       [default] Destroying VM and associated drives...
-       Vagrant instance <default-ubuntu-1204> destroyed.
-       Finished destroying <default-ubuntu-1204> (0m3.06s).
------> Testing <default-ubuntu-1204>
------> Creating <default-ubuntu-1204>...
+$ kitchen test default-ubuntu-1404
+-----> Starting Kitchen (v1.14.2)
+-----> Cleaning up any prior instances of <default-ubuntu-1404>
+-----> Destroying <default-ubuntu-1404>...
+       ==> default: Forcing shutdown of VM...
+       ==> default: Destroying VM and associated drives...
+       Vagrant instance <default-ubuntu-1404> destroyed.
+       Finished destroying <default-ubuntu-1404> (0m4.71s).
+-----> Testing <default-ubuntu-1404>
+-----> Creating <default-ubuntu-1404>...
        Bringing machine 'default' up with 'virtualbox' provider...
-       [default] Importing base box 'opscode-ubuntu-12.04'...
-       [default] Matching MAC address for NAT networking...
-       [default] Setting the name of the VM...
-       [default] Clearing any previously set forwarded ports...
-       [default] Creating shared folders metadata...
-       [default] Clearing any previously set network interfaces...
-       [default] Preparing network interfaces based on configuration...
-       [default] Forwarding ports...
-       [default] -- 22 => 2222 (adapter 1)
-       [default] Running 'pre-boot' VM customizations...
-       [default] Booting VM...
-       [default] Waiting for machine to boot. This may take a few minutes...
-[default] Machine booted and ready!       [default] Setting hostname...
-       [default] Mounting shared folders...
-       Vagrant instance <default-ubuntu-1204> created.
-       Finished creating <default-ubuntu-1204> (0m46.22s).
------> Converging <default-ubuntu-1204>...
+       ==> default: Importing base box 'bento/ubuntu-14.04'...
+==> default: Matching MAC address for NAT networking...
+       ==> default: Checking if box 'bento/ubuntu-14.04' is up to date...
+       ==> default: Setting the name of the VM: kitchen-git-cookbook-default-ubuntu-1404_default_1482059149281_96132
+       ==> default: Clearing any previously set network interfaces...
+       ==> default: Preparing network interfaces based on configuration...
+           default: Adapter 1: nat
+       ==> default: Forwarding ports...
+           default: 22 (guest) => 2222 (host) (adapter 1)
+       ==> default: Running 'pre-boot' VM customizations...
+       ==> default: Booting VM...
+       ==> default: Waiting for machine to boot. This may take a few minutes...
+           default: SSH address: 127.0.0.1:2222
+           default: SSH username: vagrant
+           default: SSH auth method: private key
+           default:
+           default: Vagrant insecure key detected. Vagrant will automatically replace
+           default: this with a newly generated keypair for better security.
+           default:
+           default: Inserting generated public key within guest...
+           default: Removing insecure key from the guest if it's present...
+           default: Key inserted! Disconnecting and reconnecting using new SSH key...
+       ==> default: Machine booted and ready!
+       ==> default: Checking for guest additions in VM...
+       ==> default: Setting hostname...
+       ==> default: Mounting shared folders...
+           default: /tmp/omnibus/cache => /Users/dom/.kitchen/cache
+       ==> default: Machine not provisioned because `--no-provision` is specified.
+       [SSH] Established
+       Vagrant instance <default-ubuntu-1404> created.
+       Finished creating <default-ubuntu-1404> (0m33.01s).
+-----> Converging <default-ubuntu-1404>...
        Preparing files for transfer
+       Preparing dna.json
        Preparing current project directory as a cookbook
        Removing non-cookbook files before transfer
------> Installing Chef Omnibus (true)
-       downloading https://www.opscode.com/chef/install.sh
-         to file /tmp/install.sh
+       Preparing solo.rb
+-----> Installing Chef Omnibus (install only if missing)
+       Downloading https://omnitruck.chef.io/install.sh to file /tmp/install.sh
+       Trying wget...
+       Download complete.
+       ubuntu 14.04 x86_64
+       Getting information for chef stable  for ubuntu...
+       downloading https://omnitruck.chef.io/stable/chef/metadata?v=&p=ubuntu&pv=14.04&m=x86_64
+         to file /tmp/install.sh.1482/metadata.txt
        trying wget...
-Downloading Chef  for ubuntu...
-Installing Chef
-Selecting previously unselected package chef.
-(Reading database ... 53291 files and directories currently installed.)
-Unpacking chef (from .../tmp.CLdJIw55/chef__amd64.deb) ...
-Setting up chef (11.8.0-1.ubuntu.12.04) ...
-Thank you for installing Chef!
-       Transfering files to <default-ubuntu-1204>
-[2013-11-30T22:10:59+00:00] INFO: Forking chef instance to converge...
-Starting Chef Client, version 11.8.0
-[2013-11-30T22:10:59+00:00] INFO: *** Chef 11.8.0 ***
-[2013-11-30T22:10:59+00:00] INFO: Chef-client pid: 1192
-[2013-11-30T22:10:59+00:00] INFO: Setting the run_list to ["recipe[git::default]"] from JSON
-[2013-11-30T22:10:59+00:00] INFO: Run List is [recipe[git::default]]
-[2013-11-30T22:10:59+00:00] INFO: Run List expands to [git::default]
-[2013-11-30T22:10:59+00:00] INFO: Starting Chef Run for default-ubuntu-1204
-[2013-11-30T22:10:59+00:00] INFO: Running start handlers
-[2013-11-30T22:10:59+00:00] INFO: Start handlers complete.
-Compiling Cookbooks...
-Converging 2 resources
-Recipe: git::default
-  * package[git] action install[2013-11-30T22:10:59+00:00] INFO: Processing package[git] action install (git::default line 1)
+       sha1	10b9026d57005aaf31289aec650931a02b5347d3
+       sha256	de5991b073fb22aa295fd0142f5e4ed3ca7da6ffe2c3fdcb01da29e4cdd0bd04
+       url	https://packages.chef.io/files/stable/chef/12.17.44/ubuntu/14.04/chef_12.17.44-1_amd64.deb
+       version	12.17.44
+       downloaded metadata file looks valid...
+       /tmp/omnibus/cache/chef_12.17.44-1_amd64.deb already exists, verifiying checksum...
+       Comparing checksum with sha256sum...
+       checksum compare succeeded, using existing file!
 
-    - install version 1:1.7.9.5-1 of package git
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
 
-  * log[Well, that was too easy] action write[2013-11-30T22:11:24+00:00] INFO: Processing log[Well, that was too easy] action write (git::default line 3)
-[2013-11-30T22:11:24+00:00] INFO: Well, that was too easy
+       You are installing an omnibus package without a version pin.  If you are installing
+       on production servers via an automated process this is DANGEROUS and you will
+       be upgraded without warning on new releases, even to new major releases.
+       Letting the version float is only appropriate in desktop, test, development or
+       CI/CD environments.
+
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+
+       Installing chef
+       installing with dpkg...
+       Selecting previously unselected package chef.
+(Reading database ... 35284 files and directories currently installed.)
+       Preparing to unpack .../chef_12.17.44-1_amd64.deb ...
+       Unpacking chef (12.17.44-1) ...
+       Setting up chef (12.17.44-1) ...
+       Thank you for installing Chef!
+       Transferring files to <default-ubuntu-1404>
+       Starting Chef Client, version 12.17.44
+       Creating a new client identity for default-ubuntu-1404 using the validator key.
+       resolving cookbooks for run list: ["git::default"]
+       Synchronizing Cookbooks:
+         - git (0.1.0)
+       Installing Cookbook Gems:
+       Compiling Cookbooks...
+       Converging 2 resources
+       Recipe: git::default
+         * apt_package[git] action install
+           - install version 1:1.9.1-1ubuntu0.3 of package git
+         * log[Well, that was too easy] action write
 
 
-[2013-11-30T22:11:24+00:00] INFO: Chef Run complete in 24.365178204 seconds
-[2013-11-30T22:11:24+00:00] INFO: Running report handlers
-[2013-11-30T22:11:24+00:00] INFO: Report handlers complete
-Chef Client finished, 2 resources updated
-       Finished converging <default-ubuntu-1204> (0m45.17s).
------> Setting up <default-ubuntu-1204>...
-Fetching: thor-0.18.1.gem (100%)
-Fetching: busser-0.6.0.gem (100%)
-Successfully installed thor-0.18.1
-Successfully installed busser-0.6.0
-2 gems installed
------> Setting up Busser
-       Creating BUSSER_ROOT in /tmp/busser
-       Creating busser binstub
-       Plugin bats installed (version 0.1.0)
+       Running handlers:
+       Running handlers complete
+       Chef Client finished, 2/2 resources updated in 14 seconds
+       Finished converging <default-ubuntu-1404> (0m22.94s).
+-----> Setting up <default-ubuntu-1404>...
+       Finished setting up <default-ubuntu-1404> (0m0.00s).
+-----> Verifying <default-ubuntu-1404>...
+       Preparing files for transfer
+-----> Installing Busser (busser)
+Fetching: thor-0.19.0.gem (100%)
+       Successfully installed thor-0.19.0
+Fetching: busser-0.7.1.gem (100%)
+       Successfully installed busser-0.7.1
+       2 gems installed
+       Installing Busser plugins: busser-bats
+       Plugin bats installed (version 0.3.0)
 -----> Running postinstall for bats plugin
-      create  /tmp/bats20131130-4164-uxjzr4/bats
-      create  /tmp/bats20131130-4164-uxjzr4/bats.tar.gz
-Installed Bats to /tmp/busser/vendor/bats/bin/bats
-      remove  /tmp/bats20131130-4164-uxjzr4
-       Finished setting up <default-ubuntu-1204> (0m4.89s).
------> Verifying <default-ubuntu-1204>...
-       Suite path directory /tmp/busser/suites does not exist, skipping.
-Uploading /tmp/busser/suites/bats/git_installed.bats (mode=0644)
+       Installed Bats to /tmp/verifier/vendor/bats/bin/bats
+       Suite path directory /tmp/verifier/suites does not exist, skipping.
+       Transferring files to <default-ubuntu-1404>
 -----> Running bats test suite
  ✓ git binary is found in PATH
 
        1 test, 0 failures
-
-       Finished verifying <default-ubuntu-1204> (0m0.98s).
------> Destroying <default-ubuntu-1204>...
-       [default] Forcing shutdown of VM...
-       [default] Destroying VM and associated drives...
-       Vagrant instance <default-ubuntu-1204> destroyed.
-       Finished destroying <default-ubuntu-1204> (0m3.48s).
-       Finished testing <default-ubuntu-1204> (1m43.82s).
------> Kitchen is finished. (1m44.11s)
+       Finished verifying <default-ubuntu-1404> (0m5.49s).
+-----> Destroying <default-ubuntu-1404>...
+       ==> default: Forcing shutdown of VM...
+       ==> default: Destroying VM and associated drives...
+       Vagrant instance <default-ubuntu-1404> destroyed.
+       Finished destroying <default-ubuntu-1404> (0m4.15s).
+       Finished testing <default-ubuntu-1404> (1m10.31s).
+-----> Kitchen is finished. (1m10.44s)
 ~~~
 
 There's only one remaining action left that needs a mention: the **Destroy Action** which... destroys the instance. With this in mind, here's what Test Kitchen is doing in the **Test Action**:
 
-1. Destroys the instance if it exists (`Cleaning up any prior instances of <default-ubuntu-1204>`)
-2. Creates the instance (`Creating <default-ubuntu-1204>`)
-3. Converges the instance (`Converging <default-ubuntu-1204>`)
-4. Sets up Busser and runner plugins on the instance (`Setting up <default-ubuntu-1204>`)
-5. Verifies the instance by running Busser tests (`Verifying <default-ubuntu-1204>`)
-6. Destroys the instance (`Destroying <default-ubuntu-1204>`)
+1. Destroys the instance if it exists (`Cleaning up any prior instances of <default-ubuntu-1404>`)
+2. Creates the instance (`Creating <default-ubuntu-1404>`)
+3. Converges the instance (`Converging <default-ubuntu-1404>`)
+4. Sets up Busser and runner plugins on the instance (`Setting up <default-ubuntu-1404>`)
+5. Verifies the instance by running Busser tests (`Verifying <default-ubuntu-1404>`)
+6. Destroys the instance (`Destroying <default-ubuntu-1404>`)
 
 A few details with regards to test:
 
@@ -133,8 +163,8 @@ Finally, let's check the status of the instance:
 
 ~~~
 $ kitchen list
-Instance             Driver   Provisioner  Last Action
-default-ubuntu-1204  Vagrant  ChefSolo     <Not Created>
+Instance             Driver   Provisioner  Verifier  Transport  Last Action    Last Error
+default-ubuntu-1404  Vagrant  ChefSolo     Busser    Ssh        <Not Created>  <None>
 ~~~
 
 Back to square one.

--- a/source/docs/getting-started/running-verify.md
+++ b/source/docs/getting-started/running-verify.md
@@ -11,33 +11,28 @@ next:
 Now to put our test to the test. For this we'll use the **verify** subcommand:
 
 ~~~
-$ kitchen verify default-ubuntu-1204
------> Starting Kitchen (v1.0.0)
------> Setting up <default-ubuntu-1204>...
-Fetching: thor-0.18.1.gem (100%)
-Fetching: busser-0.6.0.gem (100%)
-Successfully installed thor-0.18.1
-Successfully installed busser-0.6.0
-2 gems installed
------> Setting up Busser
-       Creating BUSSER_ROOT in /tmp/busser
-       Creating busser binstub
-       Plugin bats installed (version 0.1.0)
+$ kitchen verify default-ubuntu-1404
+-----> Starting Kitchen (v1.14.2)
+-----> Verifying <default-ubuntu-1404>...
+       Preparing files for transfer
+-----> Installing Busser (busser)
+Fetching: thor-0.19.0.gem (100%)
+       Successfully installed thor-0.19.0
+Fetching: busser-0.7.1.gem (100%)
+       Successfully installed busser-0.7.1
+       2 gems installed
+       Installing Busser plugins: busser-bats
+       Plugin bats installed (version 0.3.0)
 -----> Running postinstall for bats plugin
-      create  /tmp/bats20131130-4419-1fbu1/bats
-      create  /tmp/bats20131130-4419-1fbu1/bats.tar.gz
-Installed Bats to /tmp/busser/vendor/bats/bin/bats
-      remove  /tmp/bats20131130-4419-1fbu1
-       Finished setting up <default-ubuntu-1204> (0m4.25s).
------> Verifying <default-ubuntu-1204>...
-       Suite path directory /tmp/busser/suites does not exist, skipping.
-Uploading /tmp/busser/suites/bats/git_installed.bats (mode=0644)
+       Installed Bats to /tmp/verifier/vendor/bats/bin/bats
+       Suite path directory /tmp/verifier/suites does not exist, skipping.
+       Transferring files to <default-ubuntu-1404>
 -----> Running bats test suite
  ✓ git binary is found in PATH
 
-1 test, 0 failures
-       Finished verifying <default-ubuntu-1204> (0m0.87s).
------> Kitchen is finished. (0m5.45s)
+       1 test, 0 failures
+       Finished verifying <default-ubuntu-1404> (0m3.32s).
+-----> Kitchen is finished. (0m5.46s)
 $ echo $?
 0
 ~~~
@@ -46,16 +41,16 @@ $ echo $?
 
 A few things of note from the output above:
 
-* Notice the `Setting up <default-ubuntu-1204>` line? That's another action called the **Setup Action**. Usually not a big deal for most users but this action is responsible for installing the Busser RubyGem and any test runner plugins required. In our case the `busser-bats` RubyGem was installed which helped to install the bats testing framework.
-* The `Verifying <default-ubuntu-1204>` line corresponds to the start of the **Verify Action** and the `✓ git binary is found in PATH` line is output from a bats test run.
+* Notice the `Setting up <default-ubuntu-1404>` line? That's another action called the **Setup Action**. Usually not a big deal for most users but this action is responsible for installing the Busser RubyGem and any test runner plugins required. In our case the `busser-bats` RubyGem was installed which helped to install the bats testing framework.
+* The `Verifying <default-ubuntu-1404>` line corresponds to the start of the **Verify Action** and the `✓ git binary is found in PATH` line is output from a bats test run.
 * The last command (`echo $?`) is a way to print the exit code of the last run shell command. This shows that the **kitchen** command exited cleanly.
 
 Let's check the status of our instance again:
 
 ~~~
 $ kitchen list
-Instance             Driver   Provisioner  Last Action
-default-ubuntu-1204  Vagrant  ChefSolo     Verified
+Instance             Driver   Provisioner  Verifier  Transport  Last Action  Last Error
+default-ubuntu-1404  Vagrant  ChefSolo     Busser    Ssh        Verified     <None>
 ~~~
 
 Quick, commit!
@@ -82,44 +77,54 @@ So what would a failing test look like? Let's see. Open `test/integration/defaul
 And re-run the **verify** subcommand:
 
 ~~~
-$ kitchen verify default-ubuntu-1204
------> Starting Kitchen (v1.0.0)
------> Verifying <default-ubuntu-1204>...
-       Removing /tmp/busser/suites/bats
-Uploading /tmp/busser/suites/bats/git_installed.bats (mode=0644)
+$ kitchen verify default-ubuntu-1404
+-----> Starting Kitchen (v1.14.2)
+-----> Verifying <default-ubuntu-1404>...
+       Preparing files for transfer
+-----> Busser installation detected (busser)
+       Installing Busser plugins: busser-bats
+       Plugin bats already installed
+       Removing /tmp/verifier/suites/bats
+       Transferring files to <default-ubuntu-1404>
 -----> Running bats test suite
  ✗ gittt binary is found in PATH
-   (in test file /tmp/busser/suites/bats/git_installed.bats, line 5)
+          (in test file /tmp/verifier/suites/bats/git_installed.bats, line 5)
+            `[ "$status" -eq 0 ]' failed
 
-1 test, 1 failure
-Command [/tmp/busser/vendor/bats/bin/bats /tmp/busser/suites/bats] exit code was 1
->>>>>> Verify failed on instance <default-ubuntu-1204>.
->>>>>> Please see .kitchen/logs/default-ubuntu-1204.log for more details
+       1 test, 1 failure
+       !!!!!! Command [/tmp/verifier/vendor/bats/bin/bats /tmp/verifier/suites/bats] exit code was 1
 >>>>>> ------Exception-------
 >>>>>> Class: Kitchen::ActionFailed
->>>>>> Message: SSH exited (1) for command: [sh -c 'BUSSER_ROOT="/tmp/busser" GEM_HOME="/tmp/busser/gems" GEM_PATH="/tmp/busser/gems" GEM_CACHE="/tmp/busser/gems/cache" ; export BUSSER_ROOT GEM_HOME GEM_PATH GEM_CACHE; /tmp/busser/bin/busser test']
+>>>>>> Message: 1 actions failed.
+>>>>>>     Verify failed on instance <default-ubuntu-1404>.  Please see .kitchen/logs/default-ubuntu-1404.log for more details
 >>>>>> ----------------------
+>>>>>> Please see .kitchen/logs/kitchen.log for more details
+>>>>>> Also try running `kitchen diagnose --all` for configuration
 $ echo $?
-10
+20
 ~~~
 
-Not quite as pretty and happy looking. Thanks to our well-crafted test case name our bats test is telling us what is up: `✗ gittt binary is found in PATH`. Yep, not a surprise. Also note that the exit code is no longer **0** but is **10**.
+Not quite as pretty and happy looking. Thanks to our well-crafted test case name our bats test is telling us what is up: `✗ gittt binary is found in PATH`. Yep, not a surprise. Also note that the exit code is no longer **0** but is **20**.
 
 A quick revert back to our clean code gets us back to green:
 
 ~~~
 $ git checkout test/integration/default/bats/git_installed.bats
-$ kitchen verify default-ubuntu-1204
------> Starting Kitchen (v1.0.0)
------> Verifying <default-ubuntu-1204>...
-       Removing /tmp/busser/suites/bats
-Uploading /tmp/busser/suites/bats/git_installed.bats (mode=0644)
+$ kitchen verify default-ubuntu-1404
+-----> Starting Kitchen (v1.14.2)
+-----> Verifying <default-ubuntu-1404>...
+       Preparing files for transfer
+-----> Busser installation detected (busser)
+       Installing Busser plugins: busser-bats
+       Plugin bats already installed
+       Removing /tmp/verifier/suites/bats
+       Transferring files to <default-ubuntu-1404>
 -----> Running bats test suite
  ✓ git binary is found in PATH
 
-1 test, 0 failures
-       Finished verifying <default-ubuntu-1204> (0m0.89s).
------> Kitchen is finished. (0m1.19s)
+       1 test, 0 failures
+       Finished verifying <default-ubuntu-1404> (0m3.50s).
+-----> Kitchen is finished. (0m3.63s)
 ~~~
 
 It's worth pointing out that Test Kitchen is freshly uploading all your tests files for **every** invocation of the **Verify Action**. Another example of Test Kitchen optimizing for **freshness of code and configuration over speed**.

--- a/source/docs/getting-started/writing-failing-recipe.md
+++ b/source/docs/getting-started/writing-failing-recipe.md
@@ -34,68 +34,76 @@ Reasonably straight forward code. Here's what is going on:
 Now to see the fruits of our effort:
 
 ~~~
-$ kitchen verify server-ubuntu-1204
------> Starting Kitchen (v1.0.0)
------> Converging <server-ubuntu-1204>...
+$ kitchen verify server-ubuntu-1404
+-----> Starting Kitchen (v1.14.2)
+-----> Converging <server-ubuntu-1404>...
        Preparing files for transfer
+       Preparing dna.json
        Preparing current project directory as a cookbook
        Removing non-cookbook files before transfer
-       Transfering files to <server-ubuntu-1204>
-[2013-12-01T23:59:22+00:00] INFO: Forking chef instance to converge...
-Starting Chef Client, version 11.8.0
-[2013-12-01T23:59:22+00:00] INFO: *** Chef 11.8.0 ***
-[2013-12-01T23:59:22+00:00] INFO: Chef-client pid: 1307
-[2013-12-01T23:59:22+00:00] INFO: Setting the run_list to ["recipe[git::server]"] from JSON
-[2013-12-01T23:59:22+00:00] INFO: Run List is [recipe[git::server]]
-[2013-12-01T23:59:22+00:00] INFO: Run List expands to [git::server]
-[2013-12-01T23:59:22+00:00] INFO: Starting Chef Run for server-ubuntu-1204
-[2013-12-01T23:59:22+00:00] INFO: Running start handlers
-[2013-12-01T23:59:22+00:00] INFO: Start handlers complete.
-Compiling Cookbooks...
-
-================================================================================
-Recipe Compile Error in /tmp/kitchen/cookbooks/git/recipes/server.rb
-================================================================================
+       Preparing solo.rb
+-----> Chef Omnibus installation detected (install only if missing)
+       Transferring files to <server-ubuntu-1404>
+       Starting Chef Client, version 12.17.44
+       resolving cookbooks for run list: ["git::server"]
+       Synchronizing Cookbooks:
+         - git (0.1.0)
+       Installing Cookbook Gems:
+       Compiling Cookbooks...
+       [2016-12-18T15:48:29+00:00] WARN: MissingCookbookDependency:
+       Recipe `runit` is not in the run_list, and cookbook 'runit'
+       is not a dependency of any cookbook in the run_list.  To load this recipe,
+       first add a dependency on cookbook 'runit' in the cookbook you're
+       including it from in that cookbook's metadata.
 
 
-Chef::Exceptions::CookbookNotFound
-----------------------------------
-Cookbook runit not found. If you're loading runit from another cookbook, make sure you configure the dependency in your metadata
+       ================================================================================
+       Recipe Compile Error in /tmp/kitchen/cache/cookbooks/git/recipes/server.rb
+       ================================================================================
 
+       Chef::Exceptions::CookbookNotFound
+       ----------------------------------
+       Cookbook runit not found. If you're loading runit from another cookbook, make sure you configure the dependency in your metadata
 
-Cookbook Trace:
----------------
-  /tmp/kitchen/cookbooks/git/recipes/server.rb:2:in `from_file'
+       Cookbook Trace:
+       ---------------
+         /tmp/kitchen/cache/cookbooks/git/recipes/server.rb:2:in `from_file'
 
+       Relevant File Content:
+       ----------------------
+       /tmp/kitchen/cache/cookbooks/git/recipes/server.rb:
 
-Relevant File Content:
-----------------------
-/tmp/kitchen/cookbooks/git/recipes/server.rb:
-
-  1:  include_recipe "git"
-  2>> include_recipe "runit"
-  3:
-  4:  package "git-daemon-run"
+         1:  include_recipe "git"
+         2>> include_recipe "runit"
+         3:
+         4:  package "git-daemon-run"
          5:
          6:  runit_service "git-daemon" do
-         7:      sv_templates false
+         7:    sv_templates false
          8:  end
          9:
 
+       Platform:
+       ---------
+       x86_64-linux
 
-[2013-12-01T23:59:22+00:00] ERROR: Running exception handlers
-[2013-12-01T23:59:22+00:00] ERROR: Exception handlers complete
-       [2013-12-01T23:59:22+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
 
-Chef Client failed. 0 resources updated
-[2013-12-01T23:59:22+00:00] ERROR: Cookbook runit not found. If you're loading runit from another cookbook, make sure you configure the dependency in your metadata
-[2013-12-01T23:59:22+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
->>>>>> Converge failed on instance <server-ubuntu-1204>.
->>>>>> Please see .kitchen/logs/server-ubuntu-1204.log for more details
+       Running handlers:
+       [2016-12-18T15:48:29+00:00] ERROR: Running exception handlers
+       Running handlers complete
+       [2016-12-18T15:48:29+00:00] ERROR: Exception handlers complete
+       Chef Client failed. 0 resources updated in 01 seconds
+       [2016-12-18T15:48:29+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
+       [2016-12-18T15:48:29+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
+       [2016-12-18T15:48:29+00:00] ERROR: Cookbook runit not found. If you're loading runit from another cookbook, make sure you configure the dependency in your metadata
+       [2016-12-18T15:48:29+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
 >>>>>> ------Exception-------
 >>>>>> Class: Kitchen::ActionFailed
->>>>>> Message: SSH exited (1) for command: [sudo -E chef-solo --config /tmp/kitchen/solo.rb --json-attributes /tmp/kitchen/dna.json  --log_level info]
+>>>>>> Message: 1 actions failed.
+>>>>>>     Converge failed on instance <server-ubuntu-1404>.  Please see .kitchen/logs/server-ubuntu-1404.log for more details
 >>>>>> ----------------------
+>>>>>> Please see .kitchen/logs/kitchen.log for more details
+>>>>>> Also try running `kitchen diagnose --all` for configuration
 ~~~
 
 See what the Chef run told you?

--- a/source/docs/getting-started/writing-server-test.md
+++ b/source/docs/getting-started/writing-server-test.md
@@ -44,86 +44,129 @@ The beginning stanzas are RSpec and Serverspec setup and the meat of our testing
 As our primary target platform was Ubuntu 12.04, we'll target this one first for development. Now, in Test-Driven style we'll run `kitchen verify` to watch our tests fail spectacularly:
 
 ~~~
-$ kitchen verify server-ubuntu-1204
------> Starting Kitchen (v1.0.0)
------> Creating <server-ubuntu-1204>...
+$ kitchen verify server-ubuntu-1404
+-----> Starting Kitchen (v1.14.2)
+-----> Creating <server-ubuntu-1404>...
        Bringing machine 'default' up with 'virtualbox' provider...
-       [default] Importing base box 'opscode-ubuntu-12.04'...
-       [default] Matching MAC address for NAT networking...
-       [default] Setting the name of the VM...
-       [default] Clearing any previously set forwarded ports...
-       [default] Creating shared folders metadata...
-       [default] Clearing any previously set network interfaces...
-       [default] Preparing network interfaces based on configuration...
-       [default] Forwarding ports...
-       [default] -- 22 => 2222 (adapter 1)
-       [default] Running 'pre-boot' VM customizations...
-       [default] Booting VM...
-       [default] Waiting for machine to boot. This may take a few minutes...
-       [default] Machine booted and ready!
-       [default] Setting hostname...
-       [default] Mounting shared folders...
-       Vagrant instance <server-ubuntu-1204> created.
-       Finished creating <server-ubuntu-1204> (0m35.69s).
------> Converging <server-ubuntu-1204>...
+       ==> default: Importing base box 'bento/ubuntu-14.04'...
+==> default: Matching MAC address for NAT networking...
+       ==> default: Checking if box 'bento/ubuntu-14.04' is up to date...
+       ==> default: Setting the name of the VM: kitchen-git-cookbook-server-ubuntu-1404_default_1482074513896_56646
+       ==> default: Clearing any previously set network interfaces...
+       ==> default: Preparing network interfaces based on configuration...
+           default: Adapter 1: nat
+       ==> default: Forwarding ports...
+           default: 22 (guest) => 2222 (host) (adapter 1)
+       ==> default: Running 'pre-boot' VM customizations...
+       ==> default: Booting VM...
+       ==> default: Waiting for machine to boot. This may take a few minutes...
+           default: SSH address: 127.0.0.1:2222
+           default: SSH username: vagrant
+           default: SSH auth method: private key
+           default:
+           default: Vagrant insecure key detected. Vagrant will automatically replace
+           default: this with a newly generated keypair for better security.
+           default:
+           default: Inserting generated public key within guest...
+           default: Removing insecure key from the guest if it's present...
+           default: Key inserted! Disconnecting and reconnecting using new SSH key...
+       ==> default: Machine booted and ready!
+       ==> default: Checking for guest additions in VM...
+       ==> default: Setting hostname...
+       ==> default: Mounting shared folders...
+           default: /tmp/omnibus/cache => /Users/dom/.kitchen/cache
+       ==> default: Machine not provisioned because `--no-provision` is specified.
+       [SSH] Established
+       Vagrant instance <server-ubuntu-1404> created.
+       Finished creating <server-ubuntu-1404> (0m33.15s).
+-----> Converging <server-ubuntu-1404>...
        Preparing files for transfer
-       Preparing current project directory as a cookbook
+       Preparing dna.json
+       Resolving cookbook dependencies with Berkshelf 5.3.0...
        Removing non-cookbook files before transfer
------> Installing Chef Omnibus (true)
-       downloading https://www.opscode.com/chef/install.sh
-         to file /tmp/install.sh
+       Preparing solo.rb
+-----> Installing Chef Omnibus (install only if missing)
+       Downloading https://omnitruck.chef.io/install.sh to file /tmp/install.sh
+       Trying wget...
+       Download complete.
+       ubuntu 14.04 x86_64
+       Getting information for chef stable  for ubuntu...
+       downloading https://omnitruck.chef.io/stable/chef/metadata?v=&p=ubuntu&pv=14.04&m=x86_64
+         to file /tmp/install.sh.1483/metadata.txt
        trying wget...
+       sha1	10b9026d57005aaf31289aec650931a02b5347d3
+       sha256	de5991b073fb22aa295fd0142f5e4ed3ca7da6ffe2c3fdcb01da29e4cdd0bd04
+       url	https://packages.chef.io/files/stable/chef/12.17.44/ubuntu/14.04/chef_12.17.44-1_amd64.deb
+       version	12.17.44
+       downloaded metadata file looks valid...
+       /tmp/omnibus/cache/chef_12.17.44-1_amd64.deb already exists, verifiying checksum...
+       Comparing checksum with sha256sum...
+       checksum compare succeeded, using existing file!
 
-Downloading Chef  for ubuntu...
-Installing Chef
-Selecting previously unselected package chef.
-(Reading database ... 53291 files and directories currently installed.)
-Unpacking chef (from .../tmp.H1RNfFn1/chef__amd64.deb) ...
-Setting up chef (11.8.0-1.ubuntu.12.04) ...
-Thank you for installing Chef!
-       Transfering files to <server-ubuntu-1204>
-[2013-12-01T18:32:58+00:00] INFO: Forking chef instance to converge...
-Starting Chef Client, version 11.8.0
-[2013-12-01T18:32:58+00:00] INFO: *** Chef 11.8.0 ***
-[2013-12-01T18:32:58+00:00] INFO: Chef-client pid: 1147
-[2013-12-01T18:32:58+00:00] INFO: Setting the run_list to ["recipe[git::server]"] from JSON
-[2013-12-01T18:32:58+00:00] INFO: Run List is [recipe[git::server]]
-[2013-12-01T18:32:58+00:00] INFO: Run List expands to [git::server]
-[2013-12-01T18:32:58+00:00] INFO: Starting Chef Run for server-ubuntu-1204
-[2013-12-01T18:32:58+00:00] INFO: Running start handlers
-[2013-12-01T18:32:58+00:00] INFO: Start handlers complete.
-Compiling Cookbooks...
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
 
-================================================================================
-Recipe Compile Error
-================================================================================
+       You are installing an omnibus package without a version pin.  If you are installing
+       on production servers via an automated process this is DANGEROUS and you will
+       be upgraded without warning on new releases, even to new major releases.
+       Letting the version float is only appropriate in desktop, test, development or
+       CI/CD environments.
+
+       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+
+       Installing chef
+       installing with dpkg...
+       Selecting previously unselected package chef.
+(Reading database ... 35284 files and directories currently installed.)
+       Preparing to unpack .../chef_12.17.44-1_amd64.deb ...
+       Unpacking chef (12.17.44-1) ...
+       Setting up chef (12.17.44-1) ...
+       Thank you for installing Chef!
+       Transferring files to <server-ubuntu-1404>
+       Starting Chef Client, version 12.17.44
+       Creating a new client identity for server-ubuntu-1404 using the validator key.
+       resolving cookbooks for run list: ["git::server"]
+       Synchronizing Cookbooks:
+         - git (0.1.0)
+       Installing Cookbook Gems:
+       Compiling Cookbooks...
+
+       ================================================================================
+       Recipe Compile Error
+       ================================================================================
+
+       Chef::Exceptions::RecipeNotFound
+       --------------------------------
+       could not find recipe server for cookbook git
+
+       Platform:
+       ---------
+       x86_64-linux
 
 
-Chef::Exceptions::RecipeNotFound
---------------------------------
-could not find recipe server for cookbook git
-
-
-[2013-12-01T18:32:58+00:00] ERROR: Running exception handlers
-[2013-12-01T18:32:58+00:00] ERROR: Exception handlers complete
-[2013-12-01T18:32:58+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
-Chef Client failed. 0 resources updated
-[2013-12-01T18:32:58+00:00] ERROR: could not find recipe server for cookbook git
-[2013-12-01T18:32:58+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
->>>>>> Converge failed on instance <server-ubuntu-1204>.
->>>>>> Please see .kitchen/logs/server-ubuntu-1204.log for more details
+       Running handlers:
+       [2016-12-18T15:22:24+00:00] ERROR: Running exception handlers
+       Running handlers complete
+       [2016-12-18T15:22:24+00:00] ERROR: Exception handlers complete
+       Chef Client failed. 0 resources updated in 01 seconds
+       [2016-12-18T15:22:24+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
+       [2016-12-18T15:22:24+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
+       [2016-12-18T15:22:24+00:00] ERROR: could not find recipe server for cookbook git
+       [2016-12-18T15:22:24+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
 >>>>>> ------Exception-------
 >>>>>> Class: Kitchen::ActionFailed
->>>>>> Message: SSH exited (1) for command: [sudo -E chef-solo --config /tmp/kitchen/solo.rb --json-attributes /tmp/kitchen/dna.json  --log_level info]
+>>>>>> Message: 1 actions failed.
+>>>>>>     Converge failed on instance <server-ubuntu-1404>.  Please see .kitchen/logs/server-ubuntu-1404.log for more details
 >>>>>> ----------------------
+>>>>>> Please see .kitchen/logs/kitchen.log for more details
+>>>>>> Also try running `kitchen diagnose --all` for configuration
 ~~~
 
 One quick check of `kitchen list` tells us that our instance was created but not successfully converged:
 
 ~~~
-$ kitchen list server-ubuntu-1204
-Instance            Driver   Provisioner  Last Action
-server-ubuntu-1204  Vagrant  ChefSolo     Created
+$ kitchen list server-ubuntu-1404
+Instance            Driver   Provisioner  Verifier  Transport  Last Action  Last Error
+server-ubuntu-1404  Vagrant  ChefSolo     Busser    Ssh        Created      Kitchen::ActionFailed
 ~~~
 
 Yes, you can specify one or more instances with the same Ruby regular expression globbing as any other `kitchen` subcommands.


### PR DESCRIPTION
I just went through the tutorial and took the time to update the examples. 

BTW, the Ubuntu 10.04 example does not work anymore because the APT repositories are not available anymore. It is easily solved by adding :
```
  - name: ubuntu-10.04
    run_list:
      - recipe[ubuntu]
    attributes:
      ubuntu:
        archive_url: http://old-releases.ubuntu.com/ubuntu
        security_url: http://old-releases.ubuntu.com/ubuntu
```
and a Berksfile. However, that would mess with the narrative of the tutorial, so I doctored the copy/paste a bit to make it work. If 10.04 is introduced later in the tutorial (after Berksfiles and dependencies), it could still be made to work and make sense to the student.