### PR TITLE
Correcting local development location

### DIFF
--- a/source/docs/getting-started/installing.md
+++ b/source/docs/getting-started/installing.md
@@ -17,7 +17,7 @@ To follow this guide there is some software that we will need in order for Test 
 * Vagrant - a great tool to help manage development virtual machines
 * VirtualBox - a virtualization tool that let's you run virtual machines locally
 
-I know, it sounds like a lot of work but fear not. It's not overly tricky to get going, and the folks over at the [#learnchef](https://learnchef.opscode.com/) website have a handy [Workstation Setup](https://learn.chef.io/local-development/) that we can follow to get us started. Take a few minutes to get your software setup and if you run into any issues there should be some smart and capable people in the [#learnchef](http://webchat.freenode.net/?channel=learnchef) IRC chatroom to get you back on track.
+I know, it sounds like a lot of work but fear not. It's not overly tricky to get going, and the folks over at the [#learnchef](https://learnchef.opscode.com/) website have a handy [Workstation Setup](https://learn.chef.io/tutorials/local-development/) that we can follow to get us started. Take a few minutes to get your software setup and if you run into any issues there should be some smart and capable people in the [#learnchef](http://webchat.freenode.net/?channel=learnchef) IRC chatroom to get you back on track.
 
 
 > **All done? Great! Open a terminal window and let's get started.**


### PR DESCRIPTION
Looks like this URL has moved, submitting a PR to correct it: https://learn.chef.io/tutorials/local-development/