### PR TITLE
Add a Driver reference page

### DIFF
--- a/source/docs/drivers.html.md
+++ b/source/docs/drivers.html.md
@@ -10,14 +10,14 @@ Some of these are included in `chef-dk` and some are not.
 There are drivers not included in this list, and it is not intended to be
 exhaustive. However, as a sample of some of the supported platforms:
 
-- kitchen-vagrant: Vagrant driver for Kitchen
-- kitchen-google: Google Compute Engine driver for Test-Kitchen.
-- kitchen-hyperv: Hyper-V Driver for Test-Kitchen
-- kitchen-docker: A Test Kitchen Driver for Docker
-- kitchen-digitalocean: A Test Kitchen driver for DigitalOcean
-- kitchen-ec2: A Test Kitchen Driver for Amazon EC2
-- kitchen-azurerm: A driver for Test Kitchen that works with Azure Resource Manager
-- kitchen-rackspace: A Rackspace Cloud driver for Test Kitchen
+- [kitchen-vagrant](https://github.com/test-kitchen/kitchen-vagrant): Vagrant driver for Kitchen
+- [kitchen-google](https://github.com/test-kitchen/kitchen-google): Google Compute Engine driver for Test-Kitchen.
+- [kitchen-hyperv](https://github.com/test-kitchen/kitchen-hyperv): Hyper-V Driver for Test-Kitchen
+- [kitchen-docker](https://github.com/test-kitchen/kitchen-docker): A Test Kitchen Driver for Docker
+- [kitchen-digitalocean](https://github.com/test-kitchen/kitchen-digitalocean): A Test Kitchen driver for DigitalOcean
+- [kitchen-ec2](https://github.com/test-kitchen/kitchen-ec2): A Test Kitchen Driver for Amazon EC2
+- [kitchen-azurerm](https://github.com/test-kitchen/kitchen-azurerm): A driver for Test Kitchen that works with Azure Resource Manager
+- [kitchen-rackspace](https://github.com/test-kitchen/kitchen-rackspace): A Rackspace Cloud driver for Test Kitchen
 
 Some notes about specific drivers below.
 

--- a/source/docs/drivers.html.md
+++ b/source/docs/drivers.html.md
@@ -1,0 +1,84 @@
+---
+title: "Drivers"
+---
+
+Kitchen supports a driver plugin architecture which allows a user to run code
+on a variety of public cloud providers and local virtualization technologies.
+
+Some of these are included in `chef-dk` and some are not.
+
+There are drivers not included in this list, and it is not intended to be
+exhaustive. However, as a sample of some of the supported platforms:
+
+- kitchen-vagrant: Vagrant driver for Kitchen
+- kitchen-google: Google Compute Engine driver for Test-Kitchen.
+- kitchen-hyperv: Hyper-V Driver for Test-Kitchen
+- kitchen-docker: A Test Kitchen Driver for Docker
+- kitchen-digitalocean: A Test Kitchen driver for DigitalOcean
+- kitchen-ec2: A Test Kitchen Driver for Amazon EC2
+- kitchen-azurerm: A driver for Test Kitchen that works with Azure Resource Manager
+- kitchen-rackspace: A Rackspace Cloud driver for Test Kitchen
+
+Some notes about specific drivers below.
+
+
+##### Vagrant
+
+Vagrant is often considered the "minimum-viable" driver. Many projects include
+a `.kitchen.yml` which can run under Vagrant, in addition to any specific
+drivers which they may use internally or on continuous integration servers.
+
+Vagrant runs using Virtualbox VMs, so it requires a platform which supports
+virtualization. For example, it cannot run on top of Xen HVM.
+
+Vagrant is supported via the
+[kitchen-vagrant](https://rubygems.org/gems/kitchen-vagrant) gem, included by
+default in `chef-dk`.
+([Source](https://github.com/test-kitchen/kitchen-vagrant))
+
+`kitchen-vagrant` requires that you additionally have Vagrant installed.
+
+
+##### Amazon EC2
+
+Amazon Web Services' EC2 service can be used to spin up new EC2 instances for
+testing.
+
+It is supported via the [kitchen-ec2](https://rubygems.org/gems/kitchen-ec2)
+gem.
+([Source](https://github.com/test-kitchen/kitchen-ec2))
+
+`kitchen-ec2` does not have any external requirements on your system, but you
+need to configure AWS credentials which are used to manage the EC2 instances.
+This is a common property of many of the cloud-based drivers: rather than
+locally installed software, they require credentials into the service which
+they use to launch and destroy VMs.
+
+##### Docker
+
+Using Docker containers for testing often offers faster runtimes than its
+alternatives. Because containers are lighter weight than full virtualization,
+the numerous creation and deletion operations performed by Kitchen over a large
+test matrix can make this an attractive option.
+
+It is supported via the
+[kitchen-docker](https://rubygems.org/gems/kitchen-docker)
+gem.
+([Source](https://github.com/test-kitchen/kitchen-docker))
+
+`kitchen-docker` requires that you have Docker installed locally. Additionally,
+it is useful to configure your user to have sudo-less access to Docker.
+
+###### kitchen-dokken
+
+A popular alternative to `kitchen-docker`, `kitchen-dokken` is a driver which
+only works with the Chef provisioner.
+
+It is supported via the
+[kitchen-dokken](https://rubygems.org/gems/kitchen-dokken) gem.
+([Source](https://github.com/someara/kitchen-dokken))
+
+`kitchen-dokken` differs significantly from `kitchen-docker` by using bind
+mounts to share data without the need to copy it into the container.
+This can result in significant speed improvements with no additional
+configuration burden.

--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -15,19 +15,8 @@ title:  Welcome to Kitchen - KitchenCI
           or more platforms in isolation.
       p
         | A driver plugin architecture is used to run code on various cloud
-          providers and virtualization technologies such as
-          <a href="https://rubygems.org/gems/kitchen-ec2">Amazon EC2</a>,
-          <a href="https://rubygems.org/gems/kitchen-google">Google GCE</a>,
-          <a href="https://rubygems.org/gems/kitchen-azurerm">Azure</a>,
-          <a href="https://rubygems.org/gems/kitchen-bluebox">Blue Box</a>,
-          <a href="https://rubygems.org/gems/kitchen-cloudstack">CloudStack</a>,
-          <a href="https://rubygems.org/gems/kitchen-digitalocean">Digital Ocean</a>,
-          <a href="https://rubygems.org/gems/kitchen-rackspace">Rackspace</a>,
-          <a href="https://rubygems.org/gems/kitchen-openstack">OpenStack</a>,
-          <a href="https://rubygems.org/gems/kitchen-vagrant">Vagrant</a>,
-          <a href="https://rubygems.org/gems/kitchen-docker">Docker</a>,
-          <a href="https://rubygems.org/gems/kitchen-lxc">LXC containers</a>,
-          and more.
+          providers and virtualization technologies such as Vagrant, Amazon
+          EC2, and Docker. <a href="/docs/drivers">Read more</a>
       p
         | Many testing frameworks are supported out of the box including
           <a href="https://www.inspec.io/">InSpec</a>,


### PR DESCRIPTION
Remove most driver links from the index page. Instead, just list the three most commonly used drivers by name, and link to the reference.

The reference page lists all of the drivers in the test-kitchen github org as a reasonable baseline, and mentions that there are more out there. This is at least true (there's kitchen-lxc, OTTOMH), even if 
there may or may not be very complete/usable other drivers out there.
Makes explicit mention of kitchen-dokken and explains the difference from kitchen-docker.

Has sections describing the four drivers favored here, with obvious room for expansion.

Not the most pristine text ever written, but I'm happy to alter in accordance with feedback.
According to discussion in #sous-chefs , we think the drivers chosen here constitute the majority of usage, and we know that some of those which were listed prior to this change aren't well supported at all.