### PR TITLE
Add :create action to systemd_unit

### DIFF
--- a/source/docs/getting-started/adding-recipe.html.md
+++ b/source/docs/getting-started/adding-recipe.html.md
@@ -36,7 +36,7 @@ systemd_unit 'git-daemon.service' do
     DefaultInstance=tty1
     EOU
 
-  action [ :enable, :start ]
+  action [ :create, :enable, :start ]
 end
 ~~~
 


### PR DESCRIPTION
Without the :create action the systemd unit is never created and so it can't be enabled or started. A new such file or directory error is thrown:

```
       ---- Begin output of /bin/systemctl --system enable git-daemon.service ----
       STDOUT: 
       STDERR: Failed to execute operation: No such file or directory
       ---- End output of /bin/systemctl --system enable git-daemon.service ----
````