### PR TITLE
Misc updates

### DIFF
--- a/data/docs.yml
+++ b/data/docs.yml
@@ -6,3 +6,5 @@ docs_links:
   link: '/docs/verifiers'
 - title: Examples
   link: '/docs/kitchen-examples'
+- title: Dynamic Configuration
+  link: '/docs/dynamic-configuration'

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -2,6 +2,8 @@
 docs_links:
 - title: FAQ
   link: '/docs/faq'
+- title: Drivers
+  link: '/docs/drivers'
 - title: Verifiers
   link: '/docs/verifiers'
 - title: Examples

--- a/source/docs/drivers.html.md
+++ b/source/docs/drivers.html.md
@@ -2,44 +2,20 @@
 title: "Drivers"
 ---
 
+### Drivers
+
 Kitchen supports a driver plugin architecture which allows a user to run code
-on a variety of public cloud providers and local virtualization technologies.
+on a variety of cloud providers and virtualization technologies.
 
-Some of these are included in `chef-dk` and some are not.
+#### Vagrant
 
-There are drivers not included in this list, and it is not intended to be
-exhaustive. However, as a sample of some of the supported platforms:
+[kitchen-vagrant](https://github.com/test-kitchen/kitchen-vagrant) is the de facto driver as it is free and keeps everything on a the local machine.
+Vagrant itself abstracts other hypervisors, using Virtualbox by default which requires a platform which supports virtualization. For example, most hypervisors cannot run nested under other hypervisors or cloud VMs unless they explicitly support Nested Virtualization.
+The side effect is that it is often difficult to implement in CI given most CI as a Service presents VMs or Containers
 
-- [kitchen-vagrant](https://github.com/test-kitchen/kitchen-vagrant): Vagrant driver for Kitchen
-- [kitchen-google](https://github.com/test-kitchen/kitchen-google): Google Compute Engine driver for Test-Kitchen.
-- [kitchen-hyperv](https://github.com/test-kitchen/kitchen-hyperv): Hyper-V Driver for Test-Kitchen
-- [kitchen-docker](https://github.com/test-kitchen/kitchen-docker): A Test Kitchen Driver for Docker
-- [kitchen-digitalocean](https://github.com/test-kitchen/kitchen-digitalocean): A Test Kitchen driver for DigitalOcean
-- [kitchen-ec2](https://github.com/test-kitchen/kitchen-ec2): A Test Kitchen Driver for Amazon EC2
-- [kitchen-azurerm](https://github.com/test-kitchen/kitchen-azurerm): A driver for Test Kitchen that works with Azure Resource Manager
-- [kitchen-rackspace](https://github.com/test-kitchen/kitchen-rackspace): A Rackspace Cloud driver for Test Kitchen
+`kitchen-vagrant` requires that you have [Vagrant](https://www.vagrantup.com/downloads.html) and at least one hypervisor, such as VirtualBox installed.
 
-Some notes about specific drivers below.
-
-
-##### Vagrant
-
-Vagrant is often considered the "minimum-viable" driver. Many projects include
-a `.kitchen.yml` which can run under Vagrant, in addition to any specific
-drivers which they may use internally or on continuous integration servers.
-
-Vagrant runs using Virtualbox VMs, so it requires a platform which supports
-virtualization. For example, it cannot run on top of Xen HVM.
-
-Vagrant is supported via the
-[kitchen-vagrant](https://rubygems.org/gems/kitchen-vagrant) gem, included by
-default in `chef-dk`.
-([Source](https://github.com/test-kitchen/kitchen-vagrant))
-
-`kitchen-vagrant` requires that you additionally have Vagrant installed.
-
-
-##### Amazon EC2
+#### Amazon EC2
 
 Amazon Web Services' EC2 service can be used to spin up new EC2 instances for
 testing.
@@ -48,37 +24,39 @@ It is supported via the [kitchen-ec2](https://rubygems.org/gems/kitchen-ec2)
 gem.
 ([Source](https://github.com/test-kitchen/kitchen-ec2))
 
-`kitchen-ec2` does not have any external requirements on your system, but you
+[kitchen-ec2](https://github.com/test-kitchen/kitchen-ec2) does not have any external requirements on your system, but you
 need to configure AWS credentials which are used to manage the EC2 instances.
 This is a common property of many of the cloud-based drivers: rather than
 locally installed software, they require credentials into the service which
 they use to launch and destroy VMs.
 
-##### Docker
+#### Docker
 
 Using Docker containers for testing often offers faster runtimes than its
 alternatives. Because containers are lighter weight than full virtualization,
 the numerous creation and deletion operations performed by Kitchen over a large
 test matrix can make this an attractive option.
 
-It is supported via the
-[kitchen-docker](https://rubygems.org/gems/kitchen-docker)
-gem.
-([Source](https://github.com/test-kitchen/kitchen-docker))
+We have two drivers in the ecosystem for Docker and a [post](https://blog.chef.io/2018/03/06/kitchen-docker-or-kitchen-dokken-using-test-kitchen-and-docker-for-fast-cookbook-testing/) to help you choose the best for your needs.
 
-`kitchen-docker` requires that you have Docker installed locally. Additionally,
-it is useful to configure your user to have sudo-less access to Docker.
+##### kitchen-dokken
 
-###### kitchen-dokken
-
-A popular alternative to `kitchen-docker`, `kitchen-dokken` is a driver which
-only works with the Chef provisioner.
-
-It is supported via the
-[kitchen-dokken](https://rubygems.org/gems/kitchen-dokken) gem.
-([Source](https://github.com/someara/kitchen-dokken))
-
-`kitchen-dokken` differs significantly from `kitchen-docker` by using bind
+[kitchen-dokken](https://github.com/test-kitchen/kitchen-dokken) differs significantly from `kitchen-docker` by using bind
 mounts to share data without the need to copy it into the container.
 This can result in significant speed improvements with no additional
-configuration burden.
+configuration burden. `kitchen-dokken` only works with the Chef provisioner and is part of the ChefDK.
+It utlizes the `docker-api` gem for communicating with Docker.
+
+##### kitchen-docker
+
+[kitchen-docker](https://github.com/test-kitchen/kitchen-docker) requires that you have Docker installed locally. Additionally,
+it is useful to configure your user to have sudo-less access to Docker. This driver
+operates more "traditionally" like the other drivers and supports other provisioners besides Chef.
+It's useful for more complex scenarios and as it utilizes the `docker` binary directly, supports most
+things Docker does.
+
+We've covered the three most popular hypervisor options and their drivers but there are many other drivers out there. Below is a non-exhaustive list of some additional ones:
+
+- [kitchen-google](https://github.com/test-kitchen/kitchen-google)
+- [kitchen-hyperv](https://github.com/test-kitchen/kitchen-hyperv)
+- [kitchen-azurerm](https://github.com/test-kitchen/kitchen-azurerm)

--- a/source/docs/dynamic-configuration.html.md
+++ b/source/docs/dynamic-configuration.html.md
@@ -12,7 +12,7 @@ There are a few basic ways of dynamically configuring Kitchen:
 
 To specify a path to a global `config.yml`, project or local `.kitchen.yml` file, set the following environment variables:
 
-~~~
+~~~bash
 export KITCHEN_GLOBAL_YAML=/path/to/your/global/config.yml
 export KITCHEN_YAML=/path/to/your/project/.kitchen.yml
 export KITCHEN_LOCAL_YAML=/path/to/your/local/.kitchen.local.yml

--- a/source/docs/faq.html.md
+++ b/source/docs/faq.html.md
@@ -9,7 +9,7 @@ These are frequently asked questions or tips that don't have a better home just 
 
 ##### How do I add another driver other than Vagrant?
 
-First, you need to make sure the driver [exists](https://github.com/test-kitchen/test-kitchen/blob/master/ECOSYSTEM.md),
+If you're using ChefDK, check for it`chef gem list | grep $DRIVER` you need to make sure the driver [exists](https://github.com/test-kitchen/test-kitchen/blob/master/ECOSYSTEM.md),
 if it does:
 
 ~~~bash
@@ -27,38 +27,11 @@ is working as expected. There is a strong chance that the flavors, or
 image names are different per driver, so when migrating between drivers be prepared
 to change these at the very least.
 
-##### What is the deal with `.kitchen.BLAH.yml`?
-
-Although there is no strict configuration supporting this, a convention has emerged among the
-community that for public cookbooks the default `.kitchen.yml` remains vagrant and any additional drivers get their own configuration file in the form of `.kitchen.DRIVER.yml`
-
-- .kitchen.ec2.yml
-- .kitchen.dokken.yml
-
-These are meant to be used in place `.kitchen.yml` via the environment variable `KITCHEN_YAML`
-Note that it is `YAML` not `YML`.
-
-~~~bash
-$ KITCHEN_YAML=.kitchen.ec2.yml kitchen list
-
-OR
-
-$ export KITCHEN_YAML=.kitchen.ec2.yml
-$ kitchen list
-~~~
-
 Certain drivers, like `kitchen-dokken` [recommend](https://github.com/someara/kitchen-dokken#usage) setting `KITCHEN_LOCAL_YAML` environment variable to ensure these configs are used when there are multiple in a directory.
 
 ##### How do I update just test-kitchen if I'm using ChefDK?
 
-To borrow from this [discourse post](https://discourse.chef.io/t/updating-to-test-kitchen-1-6-0-in-a-chefdk-0-11-2-or-lesser/7899), one can:
-
-~~~bash
-chef gem install appbundle-updater
-appbundle-updater chefdk test-kitchen v1.6.0 # or whatever version you want update to
-~~~
-
-The appbundle-updater gem can update an "appbundled" gem in a chef or chefdk omnibus install and reference a specific git branch, tag or sha. The above uses it to pull down the v1.6.0 tag of the test-kitchen repo and then properly pins that inside an existing ChefDK installation.
+Due to the nature of how the ChefDK is built, it is not possible to update a gem that is part of the package. To get the latest versions of component software, builds from the [current](https://downloads.chef.io/chefdk/current) channel can be consumed.
 
 ##### How do I change the user to access the instance?
 

--- a/source/docs/getting-started/getting-help.html.md
+++ b/source/docs/getting-started/getting-help.html.md
@@ -14,10 +14,6 @@ Commands:
   kitchen create [INSTANCE|REGEXP|all]            # Change instance state to create. Start one or more instances
   kitchen destroy [INSTANCE|REGEXP|all]           # Change instance state to destroy. Delete all information for one or more instances
   kitchen diagnose [INSTANCE|REGEXP|all]          # Show computed diagnostic configuration
-  kitchen driver                                  # Driver subcommands
-  kitchen driver create [NAME]                    # Create a new Kitchen Driver gem project
-  kitchen driver discover                         # Discover Test Kitchen drivers published on RubyGems
-  kitchen driver help [COMMAND]                   # Describe subcommands or one specific subcommand
   kitchen exec INSTANCE|REGEXP -c REMOTE_COMMAND  # Execute command on one or more instance
   kitchen help [COMMAND]                          # Describe available commands or one specific command
   kitchen init                                    # Adds some configuration to your cookbook so Kitchen can rock

--- a/source/docs/getting-started/installing.html.md
+++ b/source/docs/getting-started/installing.html.md
@@ -33,7 +33,7 @@ kitchen version: 1.16.0
 
 ###### VirtualBox
 
-VirtualBox is a hypervisor that lets you run virtual machines on your local workstation. Obtain the correct installer for your platform [here](https://www.virtualbox.org/wiki/Downloads).
+VirtualBox is a hypervisor that lets you run virtual machines on your local workstation. Obtain the correct installer for your platform [here](https://www.virtualbox.org/wiki/Downloads). Verify that the command is accessible and in the $PATH with the following:
 
 ~~~
 $ VBoxManage --version

--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -25,13 +25,13 @@ title:  Welcome to Kitchen - KitchenCI
 
       p
         | For Chef workflows, cookbook dependency resolution via
-          <a href="https://docs.chef.io/berkshelf.html/">Berkshelf</a> or
+          <a href="https://docs.chef.io/berkshelf.html">Berkshelf</a> or
           <a href="https://docs.chef.io/config_rb_policyfile.html">Policyfiles</a>
           is supported or include a <code>cookbooks/</code> directory and
           Kitchen will know what to do.
       p
         | Kitchen is used by all
-          <a href="github.com/chef-cookbooks/">Chef-managed community
+          <a href="https://github.com/chef-cookbooks/">Chef-managed community
           cookbooks</a> and is the integration testing tool of choice for
           cookbooks.
   .columns.large-8


### PR DESCRIPTION
- Fixes #80 
- Fixes #76 
- Fixes #54 
- Adds the Drivers and Dynamic Configuration pages to the nav bar
- Removes appbundle-updater references
- Removes references to `kitchen driver` (removed in 1.19.0)